### PR TITLE
Implementing implied-repositories. Needs more functional testing, though.

### DIFF
--- a/addons/autoprox/common/src/test/java/org/commonjava/aprox/autoprox/fixture/TestAutoProxyDataManager.java
+++ b/addons/autoprox/common/src/test/java/org/commonjava/aprox/autoprox/fixture/TestAutoProxyDataManager.java
@@ -261,4 +261,10 @@ public class TestAutoProxyDataManager
         return delegate.hasArtifactStore( key );
     }
 
+    @Override
+    public RemoteRepository findRemoteRepository( final String url )
+    {
+        return delegate.findRemoteRepository( url );
+    }
+
 }

--- a/addons/implied-repos/common/pom.xml
+++ b/addons/implied-repos/common/pom.xml
@@ -35,6 +35,41 @@
       <groupId>org.commonjava.maven.galley</groupId>
       <artifactId>galley-maven</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.commonjava.aprox</groupId>
+      <artifactId>aprox-db-memory</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.maven.galley</groupId>
+      <artifactId>galley-test-harness-maven</artifactId>
+    </dependency>
   </dependencies>
   
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>confset</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <descriptorRefs>
+                <descriptorRef>confset</descriptorRef>
+                <!--
+                <descriptorRef>dataset</descriptorRef>
+                <descriptorRef>docset</descriptorRef>
+                <descriptorRef>uiset</descriptorRef>
+                -->
+              </descriptorRefs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/addons/implied-repos/common/pom.xml
+++ b/addons/implied-repos/common/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
 
     Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
@@ -18,27 +18,23 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.commonjava.aprox</groupId>
-    <artifactId>aprox-parent</artifactId>
+    <artifactId>aprox-implied-repos</artifactId>
     <version>0.20.1-SNAPSHOT</version>
   </parent>
-  
-  <artifactId>aprox-addons</artifactId>
-  <packaging>pom</packaging>
+  <artifactId>aprox-implied-repos-common</artifactId>
+  <name>AProx :: Add-Ons :: Implied Repositories :: Common</name>
 
-  <name>AProx :: Add-Ons :: Parent</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.commonjava.aprox</groupId>
+      <artifactId>aprox-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.maven.galley</groupId>
+      <artifactId>galley-maven</artifactId>
+    </dependency>
+  </dependencies>
   
-  <modules>
-    <module>autoprox</module>
-    <module>depgraph</module>
-    <module>dot-maven</module>
-    <module>folo</module>
-    <module>implied-repos</module>
-    <module>indexer</module>
-    <module>promote</module>
-    <module>revisions</module>
-    <module>setback</module>
-  </modules>
 </project>

--- a/addons/implied-repos/common/src/main/conf/conf.d/implied-repos.conf
+++ b/addons/implied-repos/common/src/main/conf/conf.d/implied-repos.conf
@@ -1,0 +1,16 @@
+# Implied-Repos is the add-on that skims POMs as they are proxied, looking for repository/pluginRepository
+# declarations. When it finds one, it figures out which groups contain the repository that contained the POM,
+# then auto-creates and adds the POM-declared repositories to the groups. It also annotates the source repo
+# with implied repositories to ensure that adding the repo to a group triggers addition of the implied
+# repositories.
+#
+ 
+[implied-repos]
+# By default, the add-on is disabled.
+#
+# This is because auto-management of implied repositories is currently add-only. When a repository has 
+# implied repos which have been added to its groups, then that repository is removed, it's currently
+# not possible to determine whether the user meant to leave the implied repositories in place. So it's not
+# safe to auto-remove them.
+#
+#enabled=false

--- a/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/ImpliedRepoMaintainer.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/ImpliedRepoMaintainer.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.aprox.implrepo;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.commonjava.aprox.audit.ChangeSummary;
+import org.commonjava.aprox.change.event.ArtifactStoreUpdateEvent;
+import org.commonjava.aprox.data.AproxDataException;
+import org.commonjava.aprox.data.StoreDataManager;
+import org.commonjava.aprox.model.core.ArtifactStore;
+import org.commonjava.aprox.model.core.Group;
+import org.commonjava.aprox.model.core.StoreKey;
+import org.commonjava.maven.atlas.ident.util.JoinString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ImpliedRepoMaintainer
+{
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private StoreDataManager storeManager;
+
+    @Inject
+    private ImpliedRepoMetadataManager metadataManager;
+
+    // FIXME: How to tell whether a repo that is implied by other repos was added manually??? 
+    // That, vs. just left there after the repo that implied it was removed???
+    // We cannot currently remove formerly implied repos because we can't distinguish between the above states.
+    public void updateImpliedStores( @Observes final ArtifactStoreUpdateEvent event )
+    {
+        for ( final ArtifactStore store : event )
+        {
+            if ( !( store instanceof Group ) )
+            {
+                continue;
+            }
+
+            final Group group = (Group) store;
+
+            List<ArtifactStore> members = null;
+            List<ArtifactStore> reachableMembers = null;
+            try
+            {
+                members = storeManager.getOrderedStoresInGroup( store.getName() );
+                reachableMembers = storeManager.getOrderedConcreteStoresInGroup( store.getName() );
+            }
+            catch ( final AproxDataException e )
+            {
+                logger.error( "Failed to retrieve member stores for group: " + store.getName(), e );
+            }
+
+            if ( members == null )
+            {
+                continue;
+            }
+
+            final Set<StoreKey> processed = new HashSet<>();
+
+            // pre-load all existing reachable members to processed list, to prevent re-adding them via 
+            // implications. Reachable means they could be in nested groups.
+            for ( final ArtifactStore member : reachableMembers )
+            {
+                processed.add( member.getKey() );
+            }
+
+            int lastLen = 0;
+            boolean changed = false;
+            final List<StoreKey> added = new ArrayList<>();
+
+            // iterate through group membership looking for implied stores that aren't already members.
+            // For each implied store:
+            //  1. load the store
+            //  2. add the implied store's key to the processed list
+            //  3. add the implied store's key to the group's membership
+            //  4. add the implied store to the members list
+            // As soon as we go an iteration without adding a new member, we've captured everything.
+            do
+            {
+                lastLen = members.size();
+
+                for ( final ArtifactStore member : members )
+                {
+                    processed.add( member.getKey() );
+                    List<StoreKey> implied;
+                    try
+                    {
+                        implied = metadataManager.getImpliedMetadata( member );
+                    }
+                    catch ( final ImpliedReposException e )
+                    {
+                        logger.error( "Failed to retrieve implied-store metadata for: " + member.getKey(), e );
+                        continue;
+                    }
+
+                    implied.removeAll( processed );
+
+                    for ( final StoreKey key : implied )
+                    {
+                        if ( processed.contains( key ) )
+                        {
+                            continue;
+                        }
+
+                        ArtifactStore impliedStore;
+                        try
+                        {
+                            impliedStore = storeManager.getArtifactStore( key );
+                        }
+                        catch ( final AproxDataException e )
+                        {
+                            logger.error( "Failed to retrieve store: " + key + " implied by: " + member.getKey(), e );
+                            continue;
+                        }
+
+                        processed.add( key );
+                        added.add( key );
+                        group.addConstituent( key );
+                        members.add( impliedStore );
+                        changed = true;
+                    }
+                }
+            }
+            while ( members.size() > lastLen );
+
+            if ( changed )
+            {
+                final String message =
+                    String.format( "On update of group: %s, implied membership was recalculated.\n\nAdded:"
+                        + "\n  %s\n\nNOTE: This update may have resulted in stores that were previously "
+                        + "implied by another member persisting as members even after the store that implied "
+                        + "them was removed.", store.getName(), new JoinString( "\n  ", added ) );
+
+                final ChangeSummary summary = new ChangeSummary( ChangeSummary.SYSTEM_USER, message );
+                try
+                {
+                    storeManager.storeGroup( group, summary );
+                }
+                catch ( final AproxDataException e )
+                {
+                    logger.error( "Failed to store implied-membership changes to: " + store.getKey(), e );
+                }
+            }
+        }
+    }
+
+}

--- a/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/ImpliedRepoMetadataManager.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/ImpliedRepoMetadataManager.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.aprox.implrepo;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.commonjava.aprox.model.core.ArtifactStore;
+import org.commonjava.aprox.model.core.StoreKey;
+import org.commonjava.aprox.model.core.io.AproxObjectMapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class ImpliedRepoMetadataManager
+{
+
+    public static final String IMPLIED_STORES = "implied_stores";
+
+    public static final String IMPLIED_BY_STORES = "implied_by_stores";
+
+    @Inject
+    private AproxObjectMapper mapper;
+
+    public void addImpliedMetadata( final ArtifactStore origin, final ArrayList<ArtifactStore> implied )
+        throws ImpliedReposException
+    {
+        try
+        {
+            final List<StoreKey> impliedKeys = new ArrayList<>( implied.size() );
+            for ( final ArtifactStore store : implied )
+            {
+                impliedKeys.add( store.getKey() );
+                updateImpliedBy( store, origin );
+            }
+
+            origin.setMetadata( IMPLIED_STORES, mapper.writeValueAsString( new ImpliedRemotesWrapper( impliedKeys ) ) );
+        }
+        catch ( final JsonProcessingException e )
+        {
+            throw new ImpliedReposException( "Failed to serialize implied stores: %s to JSON: %s. Error: %s", e,
+                                             implied, origin.getKey(), e.getMessage() );
+        }
+    }
+
+    public void updateImpliedBy( final ArtifactStore store, final ArtifactStore origin )
+        throws ImpliedReposException
+    {
+        final String metadata = store.getMetadata( IMPLIED_BY_STORES );
+
+        ImpliedRemotesWrapper wrapper;
+        if ( metadata == null )
+        {
+            wrapper = new ImpliedRemotesWrapper( Collections.singletonList( origin.getKey() ) );
+        }
+        else
+        {
+            try
+            {
+                wrapper = mapper.readValue( metadata, ImpliedRemotesWrapper.class );
+                if ( !wrapper.addItem( origin.getKey() ) )
+                {
+                    // nothing to change; set to null to signal that nothing should change.
+                    wrapper = null;
+                }
+            }
+            catch ( final IOException e )
+            {
+                throw new ImpliedReposException(
+                                                 "Failed to de-serialize implied-by stores from: %s\nJSON: %s\nError: %s",
+                                                 e, store.getKey(), metadata, e.getMessage() );
+            }
+        }
+
+        if ( wrapper != null )
+        {
+            try
+            {
+                store.setMetadata( IMPLIED_BY_STORES, mapper.writeValueAsString( wrapper ) );
+            }
+            catch ( final JsonProcessingException e )
+            {
+                throw new ImpliedReposException( "Failed to serialize implied-by stores to: %s\nJSON: %s\nError: %s",
+                                                 e, store.getKey(), metadata, e.getMessage() );
+            }
+        }
+
+    }
+
+    public List<StoreKey> getImpliedMetadata( final ArtifactStore origin )
+        throws ImpliedReposException
+    {
+        final String metadata = origin.getMetadata( IMPLIED_STORES );
+        if ( metadata == null )
+        {
+            return null;
+        }
+
+        try
+        {
+            final ImpliedRemotesWrapper wrapper = mapper.readValue( metadata, ImpliedRemotesWrapper.class );
+            return wrapper.getItems();
+        }
+        catch ( final IOException e )
+        {
+            throw new ImpliedReposException( "Failed to de-serialize implied stores from: %s\nJSON: %s\nError: %s", e,
+                                             origin.getKey(), metadata, e.getMessage() );
+        }
+    }
+
+    private static final class ImpliedRemotesWrapper
+    {
+        private List<StoreKey> items;
+
+        ImpliedRemotesWrapper( final List<StoreKey> items )
+        {
+            this.items = items;
+        }
+
+        boolean addItem( final StoreKey key )
+        {
+            if ( key == null )
+            {
+                return false;
+            }
+
+            if ( items == null )
+            {
+                items = new ArrayList<>();
+            }
+
+            if ( !items.contains( key ) )
+            {
+                return items.add( key );
+            }
+
+            return false;
+        }
+
+        @SuppressWarnings( "unused" )
+        ImpliedRemotesWrapper()
+        {
+        }
+
+        public List<StoreKey> getItems()
+        {
+            return items;
+        }
+
+        @SuppressWarnings( "unused" )
+        public void setItems( final List<StoreKey> items )
+        {
+            this.items = items;
+        }
+    }
+
+}

--- a/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/ImpliedReposAddOn.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/ImpliedReposAddOn.java
@@ -13,34 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.commonjava.aprox.depgraph.dto;
+package org.commonjava.aprox.implrepo;
 
-import java.util.Set;
+import org.commonjava.aprox.model.spi.AproxAddOnID;
+import org.commonjava.aprox.spi.AproxAddOn;
 
-import org.commonjava.maven.atlas.ident.ref.ProjectRef;
-
-public class PathsDTO 
-    extends WebOperationConfigDTO
+public class ImpliedReposAddOn
+    implements AproxAddOn
 {
 
-    /** The target artifacts which we want collect paths to. */
-    private Set<ProjectRef> targets;
+    private final AproxAddOnID id = new AproxAddOnID().withName( "Implied Repos" );
 
-    /**
-     * @return the target artifacts which we want collect paths to
-     */
-    public Set<ProjectRef> getTargets()
+    @Override
+    public AproxAddOnID getId()
     {
-        return targets;
-    }
-
-    /**
-     * @param targets
-     *            the target artifacts which we want collect paths to
-     */
-    public void setTargets( final Set<ProjectRef> targets )
-    {
-        this.targets = targets;
+        return id;
     }
 
 }

--- a/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/ImpliedReposException.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/ImpliedReposException.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.aprox.implrepo;
+
+import java.text.MessageFormat;
+import java.util.IllegalFormatException;
+
+public class ImpliedReposException
+    extends Exception
+{
+    private static final long serialVersionUID = 1L;
+
+    private Object[] params;
+
+    public ImpliedReposException( final String message, final Throwable error, final Object... params )
+    {
+        super( message, error );
+        this.params = params;
+    }
+
+    public ImpliedReposException( final String message, final Object... params )
+    {
+        super( message );
+        this.params = params;
+    }
+
+    @Override
+    public String getLocalizedMessage()
+    {
+        return getMessage();
+    }
+
+    @Override
+    public String getMessage()
+    {
+        String message = super.getMessage();
+
+        if ( params != null )
+        {
+            try
+            {
+                message = String.format( message.replaceAll( "\\{\\}", "%s" ), params );
+            }
+            catch ( final IllegalFormatException ife )
+            {
+                try
+                {
+                    message = MessageFormat.format( message, params );
+                }
+                catch ( final IllegalArgumentException iae )
+                {
+                }
+            }
+        }
+
+        return message;
+    }
+
+    private Object writeReplace()
+    {
+        final Object[] newParams = new Object[params.length];
+        int i = 0;
+        for ( final Object object : params )
+        {
+            newParams[i] = String.valueOf( object );
+            i++;
+        }
+
+        this.params = newParams;
+        return this;
+    }
+
+}

--- a/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/ImpliedRepositoryDetector.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/ImpliedRepositoryDetector.java
@@ -1,0 +1,262 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.aprox.implrepo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.apache.commons.lang.StringUtils;
+import org.commonjava.aprox.audit.ChangeSummary;
+import org.commonjava.aprox.data.AproxDataException;
+import org.commonjava.aprox.data.StoreDataManager;
+import org.commonjava.aprox.model.core.ArtifactStore;
+import org.commonjava.aprox.model.core.Group;
+import org.commonjava.aprox.model.core.RemoteRepository;
+import org.commonjava.aprox.model.core.StoreKey;
+import org.commonjava.aprox.model.galley.KeyedLocation;
+import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
+import org.commonjava.maven.atlas.ident.util.ArtifactPathInfo;
+import org.commonjava.maven.galley.event.FileAccessEvent;
+import org.commonjava.maven.galley.maven.GalleyMavenException;
+import org.commonjava.maven.galley.maven.model.view.MavenPomView;
+import org.commonjava.maven.galley.maven.model.view.RepositoryView;
+import org.commonjava.maven.galley.maven.parse.MavenPomReader;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.model.Transfer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class ImpliedRepositoryDetector
+{
+    public class ImplicationsJob
+    {
+
+        private final Transfer transfer;
+
+        public ArtifactStore store;
+
+        public MavenPomView pomView;
+
+        public ArtifactPathInfo pathInfo;
+
+        public ArrayList<ArtifactStore> implied;
+
+        public ImplicationsJob( final FileAccessEvent event )
+        {
+            this.transfer = event.getTransfer();
+        }
+
+    }
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private MavenPomReader pomReader;
+
+    @Inject
+    private StoreDataManager storeManager;
+
+    @Inject
+    private ImpliedRepoMetadataManager metadataManager;
+
+    public void detectRepos( @Observes final FileAccessEvent event )
+    {
+        final ImplicationsJob job = new ImplicationsJob( event );
+        if ( !initJob( job ) )
+        {
+            return;
+        }
+
+        addImpliedRepositories( job );
+
+        if ( job.implied != null && !job.implied.isEmpty() )
+        {
+            // Store in source remote repo metadata for future groups.
+            if ( !addImpliedMetadata( job ) )
+            {
+                return;
+            }
+
+            // Update existing groups
+            if ( !updateExistingGroups( job ) )
+            {
+                return;
+            }
+        }
+    }
+
+    private boolean initJob( final ImplicationsJob job )
+    {
+        final Transfer transfer = job.transfer;
+        if (!transfer.getPath().endsWith( ".pom" ) )
+        {
+            return false;
+        }
+        
+        final Location location = transfer.getLocation();
+        if( !(location instanceof KeyedLocation ) )
+        {
+            return false;
+        }
+        
+        final StoreKey key = ((KeyedLocation)location).getKey();
+        try
+        {
+            job.store = storeManager.getArtifactStore( key );
+        }
+        catch ( final AproxDataException e )
+        {
+            logger.error( String.format( "Cannot retrieve artifact store for: %s. Failed to process implied repositories.", key), e);
+        }
+        
+        if ( job.store == null )
+        {
+            return false;
+        }
+
+        job.pathInfo = ArtifactPathInfo.parse( transfer.getPath() );
+
+        if ( job.pathInfo == null )
+        {
+            return false;
+        }
+        
+        try
+        {
+            job.pomView =
+                pomReader.read( job.pathInfo.getProjectId(), transfer,
+                                Collections.singletonList( transfer.getLocation() ),
+                                MavenPomView.ALL_PROFILES );
+        }
+        catch ( final GalleyMavenException e )
+        {
+            logger.error( String.format( "Cannot parse: %s from: %s. Failed to process implied repositories.",
+                                         job.pathInfo.getProjectId(), transfer ), e );
+        }
+
+        if ( job.pomView == null )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean updateExistingGroups( final ImplicationsJob job )
+    {
+        final StoreKey key = job.store.getKey();
+        try
+        {
+            final Set<Group> groups = storeManager.getGroupsContaining( key );
+            if ( groups != null )
+            {
+                final String message =
+                    String.format( "Adding repositories implied by: %s\n\n  %s", key,
+                                   StringUtils.join( job.implied, "\n  " ) );
+
+                final ChangeSummary summary = new ChangeSummary( ChangeSummary.SYSTEM_USER, message );
+                for ( final Group group : groups )
+                {
+                    boolean changed = false;
+                    for ( final ArtifactStore implied : job.implied )
+                    {
+                        changed = group.addConstituent( implied ) || changed;
+                    }
+
+                    if ( changed )
+                    {
+                        storeManager.storeGroup( group, summary );
+                    }
+                }
+            }
+        }
+        catch ( final AproxDataException e )
+        {
+            logger.error( "Failed to lookup groups containing: " + key, e );
+        }
+
+        return false;
+    }
+
+    private boolean addImpliedMetadata( final ImplicationsJob job )
+    {
+        try
+        {
+            metadataManager.addImpliedMetadata( job.store, job.implied );
+            return true;
+        }
+        catch ( final ImpliedReposException e )
+        {
+            logger.error( "Failed to store list of implied stores in: " + job.store.getKey(), e );
+        }
+
+        return false;
+    }
+
+    private void addImpliedRepositories( final ImplicationsJob job )
+    {
+        job.implied = new ArrayList<ArtifactStore>();
+
+        final List<List<RepositoryView>> repoLists =
+            Arrays.asList( job.pomView.getAllRepositories(), job.pomView.getAllPluginRepositories() );
+        for ( final List<RepositoryView> repos : repoLists )
+        {
+            if ( repos == null || repos.isEmpty() )
+            {
+                continue;
+            }
+
+            for ( final RepositoryView repo : repos )
+            {
+                RemoteRepository rr = storeManager.findRemoteRepository( repo.getUrl() );
+                if ( rr == null )
+                {
+                    final ProjectVersionRef gav = job.pathInfo.getProjectId();
+
+                    rr = new RemoteRepository( repo.getName(), repo.getUrl() );
+                    rr.setDescription( "Implicitly created from repository declaration in POM: " + gav );
+
+                    final String changelog =
+                        String.format( "Adding remote repository: %s (url: %s), which is implied by the POM: %s (at: %s/%s)",
+                                       repo.getName(), repo.getUrl(), gav, job.transfer.getLocation()
+                                                                                       .getUri(),
+                                       job.transfer.getPath() );
+
+                    final ChangeSummary summary = new ChangeSummary( ChangeSummary.SYSTEM_USER, changelog );
+                    try
+                    {
+                        storeManager.storeRemoteRepository( rr, summary );
+                        job.implied.add( rr );
+                    }
+                    catch ( final AproxDataException e )
+                    {
+                        logger.error( String.format( "Cannot add implied remote repo: %s from: %s (transfer: %s). Failed to store new remote repository.",
+                                                     repo.getUrl(), gav, job.transfer ), e );
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/conf/ImpliedRepoConfig.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/conf/ImpliedRepoConfig.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.aprox.implrepo.conf;
+
+import java.io.File;
+import java.io.InputStream;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.commonjava.aprox.conf.AbstractAproxConfigInfo;
+import org.commonjava.aprox.conf.AbstractAproxFeatureConfig;
+import org.commonjava.aprox.conf.AproxConfigClassInfo;
+import org.commonjava.aprox.conf.AproxConfigInfo;
+import org.commonjava.web.config.ConfigurationException;
+import org.commonjava.web.config.annotation.ConfigName;
+import org.commonjava.web.config.annotation.SectionName;
+
+@SectionName( "implied-repos" )
+@Alternative
+@Named
+public class ImpliedRepoConfig
+{
+
+    @javax.enterprise.context.ApplicationScoped
+    public static class ConfigInfo
+        extends AbstractAproxConfigInfo
+    {
+        public ConfigInfo()
+        {
+            super( ImpliedRepoConfig.class );
+        }
+
+        @Override
+        public String getDefaultConfigFileName()
+        {
+            return new File( AproxConfigInfo.CONF_INCLUDES_DIR, "implied-repos.conf" ).getPath();
+        }
+
+        @Override
+        public InputStream getDefaultConfig()
+        {
+            return Thread.currentThread()
+                         .getContextClassLoader()
+                         .getResourceAsStream( "default-implied-repos.conf" );
+        }
+    }
+
+    public static final boolean DEFAULT_ENABLED = false;
+
+    private Boolean enabled;
+
+    public ImpliedRepoConfig()
+    {
+    }
+
+    public boolean isEnabled()
+    {
+        return enabled == null ? DEFAULT_ENABLED : enabled;
+    }
+
+    @ConfigName( "enabled" )
+    public void setEnabled( final Boolean enabled )
+    {
+        this.enabled = enabled;
+    }
+
+    @javax.enterprise.context.ApplicationScoped
+    public static class FeatureConfig
+        extends AbstractAproxFeatureConfig<ImpliedRepoConfig, ImpliedRepoConfig>
+    {
+        @Inject
+        private ConfigInfo info;
+
+        public FeatureConfig()
+        {
+            super( ImpliedRepoConfig.class );
+        }
+
+        @Produces
+        @Default
+        @ApplicationScoped
+        public ImpliedRepoConfig getFlatFileConfig()
+            throws ConfigurationException
+        {
+            return getConfig();
+        }
+
+        @Override
+        public AproxConfigClassInfo getInfo()
+        {
+            return info;
+        }
+    }
+
+}

--- a/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/data/ImpliedRepoMetadataManager.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/data/ImpliedRepoMetadataManager.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.commonjava.aprox.implrepo;
+package org.commonjava.aprox.implrepo.data;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -22,6 +22,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.commonjava.aprox.implrepo.ImpliedReposException;
 import org.commonjava.aprox.model.core.ArtifactStore;
 import org.commonjava.aprox.model.core.StoreKey;
 import org.commonjava.aprox.model.core.io.AproxObjectMapper;
@@ -38,7 +39,16 @@ public class ImpliedRepoMetadataManager
     @Inject
     private AproxObjectMapper mapper;
 
-    public void addImpliedMetadata( final ArtifactStore origin, final ArrayList<ArtifactStore> implied )
+    protected ImpliedRepoMetadataManager()
+    {
+    }
+
+    public ImpliedRepoMetadataManager( final AproxObjectMapper mapper )
+    {
+        this.mapper = mapper;
+    }
+
+    public void addImpliedMetadata( final ArtifactStore origin, final List<ArtifactStore> implied )
         throws ImpliedReposException
     {
         try

--- a/addons/implied-repos/common/src/main/resources/META-INF/beans.xml
+++ b/addons/implied-repos/common/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2014 Red Hat, Inc..
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the GNU Public License v3.0
+  which accompanies this distribution, and is available at
+  http://www.gnu.org/licenses/gpl.html
+  
+  Contributors:
+      Red Hat, Inc. - initial API and implementation
+-->
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee 
+      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/addons/implied-repos/common/src/main/resources/default-implied-repos.conf
+++ b/addons/implied-repos/common/src/main/resources/default-implied-repos.conf
@@ -1,0 +1,16 @@
+# Implied-Repos is the add-on that skims POMs as they are proxied, looking for repository/pluginRepository
+# declarations. When it finds one, it figures out which groups contain the repository that contained the POM,
+# then auto-creates and adds the POM-declared repositories to the groups. It also annotates the source repo
+# with implied repositories to ensure that adding the repo to a group triggers addition of the implied
+# repositories.
+#
+ 
+[implied-repos]
+# By default, the add-on is disabled.
+#
+# This is because auto-management of implied repositories is currently add-only. When a repository has 
+# implied repos which have been added to its groups, then that repository is removed, it's currently
+# not possible to determine whether the user meant to leave the implied repositories in place. So it's not
+# safe to auto-remove them.
+#
+#enabled=false

--- a/addons/implied-repos/common/src/test/java/org/commonjava/aprox/implrepo/change/ImpliedRepoMaintainerTest.java
+++ b/addons/implied-repos/common/src/test/java/org/commonjava/aprox/implrepo/change/ImpliedRepoMaintainerTest.java
@@ -1,0 +1,96 @@
+package org.commonjava.aprox.implrepo.change;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.commonjava.aprox.audit.ChangeSummary;
+import org.commonjava.aprox.change.event.ArtifactStoreUpdateEvent;
+import org.commonjava.aprox.change.event.ArtifactStoreUpdateType;
+import org.commonjava.aprox.data.StoreDataManager;
+import org.commonjava.aprox.implrepo.conf.ImpliedRepoConfig;
+import org.commonjava.aprox.implrepo.data.ImpliedRepoMetadataManager;
+import org.commonjava.aprox.mem.data.MemoryStoreDataManager;
+import org.commonjava.aprox.model.core.ArtifactStore;
+import org.commonjava.aprox.model.core.Group;
+import org.commonjava.aprox.model.core.RemoteRepository;
+import org.commonjava.aprox.model.core.io.AproxObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ImpliedRepoMaintainerTest
+{
+
+    private ImpliedRepoMaintainer maintainer;
+
+    private StoreDataManager storeDataManager;
+
+    private ChangeSummary summary;
+
+    private ImpliedRepoMetadataManager metadataManager;
+
+    @Before
+    public void setup()
+    {
+        storeDataManager = new MemoryStoreDataManager();
+        metadataManager = new ImpliedRepoMetadataManager( new AproxObjectMapper( true ) );
+
+        final ImpliedRepoConfig config = new ImpliedRepoConfig();
+        config.setEnabled( true );
+
+        maintainer = new ImpliedRepoMaintainer( storeDataManager, metadataManager, config );
+        summary = new ChangeSummary( ChangeSummary.SYSTEM_USER, "test setup" );
+    }
+
+    @Test
+    public void addImpliedRepoWhenRepoAddedToGroup()
+        throws Exception
+    {
+        final Group g = new Group( "test" );
+        storeDataManager.storeGroup( g, summary );
+
+        final RemoteRepository repo1 = new RemoteRepository( "one", "http://www.foo.com/repo" );
+        storeDataManager.storeRemoteRepository( repo1, summary );
+
+        final RemoteRepository repo2 = new RemoteRepository( "one", "http://www.foo.com/repo" );
+        storeDataManager.storeRemoteRepository( repo2, summary );
+
+        metadataManager.addImpliedMetadata( repo1, Arrays.<ArtifactStore> asList( repo2 ) );
+
+        g.addConstituent( repo1 );
+
+        final ArtifactStoreUpdateEvent event = new ArtifactStoreUpdateEvent( ArtifactStoreUpdateType.UPDATE, g );
+        maintainer.updateImpliedStores( event );
+
+        assertThat( g.getConstituents()
+                     .contains( repo2.getKey() ), equalTo( true ) );
+    }
+
+    @Test
+    public void dontRemoveImpliedRepoWhenRepoRemovedFromGroup()
+        throws Exception
+    {
+        final Group g = new Group( "test" );
+        storeDataManager.storeGroup( g, summary );
+
+        final RemoteRepository repo1 = new RemoteRepository( "one", "http://www.foo.com/repo" );
+        storeDataManager.storeRemoteRepository( repo1, summary );
+
+        final RemoteRepository repo2 = new RemoteRepository( "one", "http://www.foo.com/repo" );
+        storeDataManager.storeRemoteRepository( repo2, summary );
+
+        metadataManager.addImpliedMetadata( repo1, Arrays.<ArtifactStore> asList( repo2 ) );
+
+        // Simulates removal of repo1...odd, I know, but since they post-process these updates, it's what the 
+        // event observers would see.
+        g.addConstituent( repo2 );
+
+        final ArtifactStoreUpdateEvent event = new ArtifactStoreUpdateEvent( ArtifactStoreUpdateType.UPDATE, g );
+        maintainer.updateImpliedStores( event );
+
+        assertThat( g.getConstituents()
+                     .contains( repo2.getKey() ), equalTo( true ) );
+    }
+
+}

--- a/addons/implied-repos/common/src/test/java/org/commonjava/aprox/implrepo/change/ImpliedRepositoryDetectorTest.java
+++ b/addons/implied-repos/common/src/test/java/org/commonjava/aprox/implrepo/change/ImpliedRepositoryDetectorTest.java
@@ -1,0 +1,125 @@
+package org.commonjava.aprox.implrepo.change;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.aprox.audit.ChangeSummary;
+import org.commonjava.aprox.data.StoreDataManager;
+import org.commonjava.aprox.implrepo.conf.ImpliedRepoConfig;
+import org.commonjava.aprox.implrepo.data.ImpliedRepoMetadataManager;
+import org.commonjava.aprox.mem.data.MemoryStoreDataManager;
+import org.commonjava.aprox.model.core.Group;
+import org.commonjava.aprox.model.core.RemoteRepository;
+import org.commonjava.aprox.model.core.StoreKey;
+import org.commonjava.aprox.model.core.StoreType;
+import org.commonjava.aprox.model.core.io.AproxObjectMapper;
+import org.commonjava.aprox.model.galley.RepositoryLocation;
+import org.commonjava.maven.galley.event.FileStorageEvent;
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+import org.commonjava.maven.galley.testing.core.ApiFixture;
+import org.commonjava.maven.galley.testing.maven.GalleyMavenFixture;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ImpliedRepositoryDetectorTest
+{
+
+    private ImpliedRepositoryDetector detector;
+
+    private StoreDataManager storeManager;
+
+    @Rule
+    public GalleyMavenFixture fixture = new GalleyMavenFixture( new ApiFixture() );
+
+    private RemoteRepository remote;
+
+    private Group group;
+
+    private ImpliedRepoMetadataManager metadataManager;
+
+    private ChangeSummary summary;
+
+    @Before
+    public void setup()
+        throws Exception
+    {
+        fixture.initMissingComponents();
+
+        storeManager = new MemoryStoreDataManager();
+
+        metadataManager =
+            new ImpliedRepoMetadataManager( new AproxObjectMapper( true ) );
+
+        final ImpliedRepoConfig config = new ImpliedRepoConfig();
+        config.setEnabled( true );
+
+        detector = new ImpliedRepositoryDetector( fixture.getPomReader(), storeManager, metadataManager, config );
+
+        summary = new ChangeSummary( ChangeSummary.SYSTEM_USER, "test setup" );
+
+        remote = new RemoteRepository( "test", "http://www.foo.com/repo" );
+        group = new Group( "group", remote.getKey() );
+
+        storeManager.storeRemoteRepository( remote, summary );
+        storeManager.storeGroup( group, summary );
+    }
+
+    @Test
+    public void addRepositoryFromPomStorageEvent()
+        throws Exception
+    {
+        final String path = "/path/to/1/to-1.pom";
+        final Transfer txfr = fixture.getCache()
+                                     .getTransfer( new ConcreteResource( new RepositoryLocation( remote ), path ) );
+
+        final OutputStream out = txfr.openOutputStream( TransferOperation.UPLOAD, false );
+        final InputStream in = Thread.currentThread()
+                                     .getContextClassLoader()
+                                     .getResourceAsStream( "one-repo.pom" );
+        IOUtils.copy( in, out );
+        IOUtils.closeQuietly( in );
+        IOUtils.closeQuietly( out );
+
+        final FileStorageEvent event = new FileStorageEvent( TransferOperation.DOWNLOAD, txfr );
+        detector.detectRepos( event );
+
+        assertThat( storeManager.getRemoteRepository( "repo-one" ), notNullValue() );
+
+        assertThat( group.getConstituents()
+                         .contains( new StoreKey( StoreType.remote, "repo-one" ) ), equalTo( true ) );
+    }
+
+    @Test
+    public void addImpliedPluginRepositoryToNewGroup()
+        throws Exception
+    {
+        final String path = "/path/to/1/to-1.pom";
+        final Transfer txfr = fixture.getCache()
+                                     .getTransfer( new ConcreteResource( new RepositoryLocation( remote ), path ) );
+
+        final OutputStream out = txfr.openOutputStream( TransferOperation.UPLOAD, false );
+        final InputStream in = Thread.currentThread()
+                                     .getContextClassLoader()
+                                     .getResourceAsStream( "one-plugin-repo.pom" );
+        IOUtils.copy( in, out );
+        IOUtils.closeQuietly( in );
+        IOUtils.closeQuietly( out );
+
+        final FileStorageEvent event = new FileStorageEvent( TransferOperation.DOWNLOAD, txfr );
+        detector.detectRepos( event );
+
+        assertThat( storeManager.getRemoteRepository( "repo-one" ), notNullValue() );
+
+        assertThat( group.getConstituents()
+                         .contains( new StoreKey( StoreType.remote, "repo-one" ) ), equalTo( true ) );
+    }
+
+}

--- a/addons/implied-repos/common/src/test/resources/META-INF/beans.xml
+++ b/addons/implied-repos/common/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2014 Red Hat, Inc..
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the GNU Public License v3.0
+  which accompanies this distribution, and is available at
+  http://www.gnu.org/licenses/gpl.html
+  
+  Contributors:
+      Red Hat, Inc. - initial API and implementation
+-->
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee 
+      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/addons/implied-repos/common/src/test/resources/one-plugin-repo.pom
+++ b/addons/implied-repos/common/src/test/resources/one-plugin-repo.pom
@@ -1,0 +1,31 @@
+<!--
+
+    Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>org.test</groupId>
+  <artifactId>one-repo</artifactId>
+  <version>1</version>
+  
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo-one</id>
+      <url>http://www.bar.com/repo</url>
+    </pluginRepository>
+  </pluginRepositories>
+</project>

--- a/addons/implied-repos/common/src/test/resources/one-repo.pom
+++ b/addons/implied-repos/common/src/test/resources/one-repo.pom
@@ -1,0 +1,31 @@
+<!--
+
+    Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>org.test</groupId>
+  <artifactId>one-repo</artifactId>
+  <version>1</version>
+  
+  <repositories>
+    <repository>
+      <id>repo-one</id>
+      <url>http://www.bar.com/repo</url>
+    </repository>
+  </repositories>
+</project>

--- a/addons/implied-repos/ftests/pom.xml
+++ b/addons/implied-repos/ftests/pom.xml
@@ -1,0 +1,61 @@
+<!--
+
+    Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <groupId>org.commonjava.aprox</groupId>
+    <artifactId>aprox-implied-repos</artifactId>
+    <version>0.20.1-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>aprox-ftests-implied-repos</artifactId>
+  <name>AProx :: Implied Repositories :: Functional Tests</name>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.commonjava.aprox</groupId>
+      <artifactId>aprox-implied-repos-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.aprox</groupId>
+      <artifactId>aprox-client-core-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.aprox</groupId>
+      <artifactId>aprox-ftests-common</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.aprox</groupId>
+      <artifactId>aprox-test-fixtures-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/aprox/implrepo/skim/AbstractSkimFunctionalTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/aprox/implrepo/skim/AbstractSkimFunctionalTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.aprox.implrepo.skim;
+
+import static org.commonjava.aprox.model.core.StoreType.group;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.commons.io.FileUtils;
+import org.commonjava.aprox.boot.AproxBootException;
+import org.commonjava.aprox.ftest.core.AbstractAproxFunctionalTest;
+import org.commonjava.aprox.model.core.Group;
+import org.commonjava.aprox.model.core.RemoteRepository;
+import org.commonjava.aprox.test.fixture.core.CoreServerFixture;
+import org.commonjava.aprox.test.fixture.core.TestHttpServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AbstractSkimFunctionalTest
+    extends AbstractAproxFunctionalTest
+{
+
+    protected static final String TEST_REPO = "test";
+
+    protected static final String PUBLIC = "public";
+
+    protected final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Rule
+    public TestHttpServer server = new TestHttpServer( "repos" );
+
+    @Before
+    public void setupTestStores()
+        throws Exception
+    {
+        final String changelog = "Create test structures";
+
+        final String url = server.formatUrl( TEST_REPO );
+        final RemoteRepository testRepo =
+            client.stores()
+                  .create( new RemoteRepository( TEST_REPO, url ), changelog, RemoteRepository.class );
+
+        Group g;
+        if ( client.stores()
+                   .exists( group, PUBLIC ) )
+        {
+            System.out.println( "Loading pre-existing public group." );
+            g = client.stores()
+                      .load( group, PUBLIC, Group.class );
+        }
+        else
+        {
+            System.out.println( "Creating new group 'public'" );
+            g = client.stores()
+                      .create( new Group( PUBLIC ), changelog, Group.class );
+        }
+
+        g.setConstituents( Arrays.asList( testRepo.getKey() ) );
+        client.stores()
+              .update( g, changelog );
+    }
+
+    @Override
+    protected CoreServerFixture newServerFixture()
+        throws AproxBootException, IOException
+    {
+        final CoreServerFixture fixture = new CoreServerFixture();
+
+        final File confFile = new File( fixture.getBootOptions()
+                                               .getAproxHome(), "etc/aprox/conf.d/implied-repos.conf" );
+
+        confFile.getParentFile()
+                .mkdirs();
+
+        logger.info( "Writing implied-repos configuration to: {}", confFile );
+        FileUtils.write( confFile, "[implied-repos]\nenabled=true" );
+
+        return fixture;
+    }
+}

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/aprox/implrepo/skim/PomWithRepoAddsRepoToGroupTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/aprox/implrepo/skim/PomWithRepoAddsRepoToGroupTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.aprox.implrepo.skim;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.aprox.implrepo.data.ImpliedRepoMetadataManager;
+import org.commonjava.aprox.model.core.Group;
+import org.commonjava.aprox.model.core.RemoteRepository;
+import org.commonjava.aprox.model.core.StoreKey;
+import org.commonjava.aprox.model.core.StoreType;
+import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
+import org.commonjava.maven.galley.maven.parse.PomPeek;
+import org.junit.Test;
+
+public class PomWithRepoAddsRepoToGroupTest
+    extends AbstractSkimFunctionalTest
+{
+
+    private static final String REPO = "repo-one";
+
+    @Test
+    public void skimPomForRepoAndAddIt() throws Exception
+    {
+        InputStream stream = Thread.currentThread()
+                                   .getContextClassLoader()
+                                   .getResourceAsStream( "one-repo.pom" );
+        String pom = IOUtils.toString( stream );
+        IOUtils.closeQuietly( stream );
+        pom = pom.replace( "@one-repo.url@", server.formatUrl( REPO ) );
+        
+        final PomPeek peek = new PomPeek( pom, false );
+        final ProjectVersionRef gav = peek.getKey();
+        
+        final String path = String.format( "%s/%s/%s/%s-%s.pom", gav.getGroupId().replace('.', '/'), gav.getArtifactId(), gav.getVersionString(), gav.getArtifactId(), gav.getVersionString() );
+        
+        server.expect( server.formatUrl( TEST_REPO, path ), 200, pom );
+
+        stream = client.content().get( StoreType.group, PUBLIC, path );
+        final String downloaded = IOUtils.toString( stream );
+        IOUtils.closeQuietly( stream );
+        
+        assertThat( "SANITY: downloaded POM is wrong!", downloaded, equalTo( pom ) );
+        
+        // sleep while event observer runs...
+        System.out.println( "Waiting 5s for events to run." );
+        Thread.sleep( 5000 );
+
+        final Group g = client.stores().load( StoreType.group, PUBLIC, Group.class );
+        assertThat( "Group membership does not contain implied repository",
+                    g.getConstituents()
+                     .contains( new StoreKey( StoreType.remote, REPO ) ), equalTo( true ) );
+
+        RemoteRepository r = client.stores()
+                                         .load( StoreType.remote, TEST_REPO, RemoteRepository.class );
+
+        String metadata = r.getMetadata( ImpliedRepoMetadataManager.IMPLIED_STORES );
+
+        assertThat( "Reference to repositories implied by POMs in this repo is missing from metadata.",
+                    metadata.contains( "remote:" + REPO ), equalTo( true ) );
+
+        r = client.stores()
+                  .load( StoreType.remote, REPO, RemoteRepository.class );
+
+        metadata = r.getMetadata( ImpliedRepoMetadataManager.IMPLIED_BY_STORES );
+
+        assertThat( "Backref to repo with pom that implies this repo is missing from metadata.",
+                    metadata.contains( "remote:" + TEST_REPO ), equalTo( true ) );
+    }
+
+}

--- a/addons/implied-repos/ftests/src/main/resources/one-repo.pom
+++ b/addons/implied-repos/ftests/src/main/resources/one-repo.pom
@@ -1,0 +1,31 @@
+<!--
+
+    Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>org.test</groupId>
+  <artifactId>one-repo</artifactId>
+  <version>1</version>
+  
+  <repositories>
+    <repository>
+      <id>repo-one</id>
+      <url>@one-repo.url@</url>
+    </repository>
+  </repositories>
+</project>

--- a/addons/implied-repos/pom.xml
+++ b/addons/implied-repos/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
 
     Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
@@ -18,27 +18,18 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.commonjava.aprox</groupId>
-    <artifactId>aprox-parent</artifactId>
+    <artifactId>aprox-addons</artifactId>
     <version>0.20.1-SNAPSHOT</version>
   </parent>
-  
-  <artifactId>aprox-addons</artifactId>
+  <artifactId>aprox-implied-repos</artifactId>
+  <name>AProx :: Add-Ons :: Implied Repositories :: Parent</name>
   <packaging>pom</packaging>
 
-  <name>AProx :: Add-Ons :: Parent</name>
-  
   <modules>
-    <module>autoprox</module>
-    <module>depgraph</module>
-    <module>dot-maven</module>
-    <module>folo</module>
-    <module>implied-repos</module>
-    <module>indexer</module>
-    <module>promote</module>
-    <module>revisions</module>
-    <module>setback</module>
+    <module>ftests</module>
+    <module>common</module>
   </modules>
+
 </project>

--- a/addons/indexer/src/main/java/org/commonjava/aprox/indexer/IndexHandler.java
+++ b/addons/indexer/src/main/java/org/commonjava/aprox/indexer/IndexHandler.java
@@ -135,6 +135,7 @@ public class IndexHandler
 
     public void onStorage( @Observes final FileStorageEvent event )
     {
+        logger.info( "Handling storage event: {}", event );
         final Transfer item = event.getTransfer();
         final StoreKey key = LocationUtils.getKey( item );
         final String path = item.getPath();

--- a/api/src/main/java/org/commonjava/aprox/change/event/AproxFileEventManager.java
+++ b/api/src/main/java/org/commonjava/aprox/change/event/AproxFileEventManager.java
@@ -24,6 +24,8 @@ import org.commonjava.maven.galley.event.FileDeletionEvent;
 import org.commonjava.maven.galley.event.FileErrorEvent;
 import org.commonjava.maven.galley.event.FileNotFoundEvent;
 import org.commonjava.maven.galley.event.FileStorageEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Helper class to provide simple methods to handle null-checking, etc. around the firing of AProx filesystem events.
@@ -32,6 +34,8 @@ import org.commonjava.maven.galley.event.FileStorageEvent;
 public class AproxFileEventManager
     implements org.commonjava.maven.galley.spi.event.FileEventManager
 {
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     @Inject
     private Event<FileStorageEvent> storageEvent;
@@ -80,9 +84,15 @@ public class AproxFileEventManager
 
     private <T> void doFire( final Event<T> eventQ, final T evt )
     {
+        logger.info( "Firing {} event: {}", evt.getClass()
+                                               .getSimpleName(), evt );
         if ( eventQ != null )
         {
             eventQ.fire( evt );
+        }
+        else
+        {
+            logger.warn( "ERROR: No event queue available for firing: {}", evt );
         }
     }
 }

--- a/api/src/main/java/org/commonjava/aprox/data/StoreDataManager.java
+++ b/api/src/main/java/org/commonjava/aprox/data/StoreDataManager.java
@@ -265,4 +265,9 @@ public interface StoreDataManager
      */
     boolean hasArtifactStore( StoreKey key );
 
+    /**
+     * Find a remote repository with a URL that matches the given one, and return it...or null.
+     */
+    RemoteRepository findRemoteRepository( String url );
+
 }

--- a/bindings/jaxrs/src/main/java/org/commonjava/aprox/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/aprox/core/bind/jaxrs/ContentAccessHandler.java
@@ -250,6 +250,8 @@ public class ContentAccessHandler
 
                     response = Response.ok( new TransferStreamingOutput( item ) )
                                        .header( ApplicationHeader.content_type.key(), contentType )
+                                .header( ApplicationHeader.last_modified.key(),
+                                         HttpUtils.formatDateHeader( item.lastModified() ) )
                                        .build();
                 }
             }

--- a/core/src/main/java/org/commonjava/aprox/core/conf/DefaultAproxConfigFactory.java
+++ b/core/src/main/java/org/commonjava/aprox/core/conf/DefaultAproxConfigFactory.java
@@ -159,9 +159,16 @@ public class DefaultAproxConfigFactory
         {
             final String fname = section.getDefaultConfigFileName();
             final File file = new File( dir, fname );
+            if ( !"main.conf".equals( fname ) && file.exists() )
+            {
+                logger.info( "NOT writing default configuration to: {}. That file already exists.", file );
+                return;
+            }
+
             file.getParentFile()
                 .mkdirs();
 
+            logger.info( "Writing defaults for: {} to: {}", section.getSectionName(), file );
             FileOutputStream out = null;
             try
             {

--- a/core/src/main/java/org/commonjava/aprox/core/ctl/ContentController.java
+++ b/core/src/main/java/org/commonjava/aprox/core/ctl/ContentController.java
@@ -112,7 +112,7 @@ public class ContentController
         final ArtifactStore store = getStore( key );
 
         final boolean deleted = contentManager.delete( store, path );
-        return deleted ? ApplicationStatus.OK : ApplicationStatus.NOT_FOUND;
+        return deleted ? ApplicationStatus.NO_CONTENT : ApplicationStatus.NOT_FOUND;
     }
 
     public Transfer get( final StoreType type, final String name, final String path )

--- a/deployments/launchers/savant/pom.xml
+++ b/deployments/launchers/savant/pom.xml
@@ -117,6 +117,12 @@
       <type>tar.gz</type>
       <classifier>confset</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.commonjava.aprox</groupId>
+      <artifactId>aprox-implied-repos-common</artifactId>
+      <type>tar.gz</type>
+      <classifier>confset</classifier>
+    </dependency>
   </dependencies>
   
   <build>

--- a/embedder-tests/savant/pom.xml
+++ b/embedder-tests/savant/pom.xml
@@ -44,6 +44,10 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.aprox</groupId>
+      <artifactId>aprox-ftests-implied-repos</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.aprox</groupId>
       <artifactId>aprox-ftests-promote</artifactId>
     </dependency>
     <dependency>
@@ -71,6 +75,7 @@
             <dependenciesToScan>
               <dependency>org.commonjava.aprox:aprox-ftests-core</dependency>
               <dependency>org.commonjava.aprox:aprox-ftests-folo</dependency>
+              <dependency>org.commonjava.aprox:aprox-ftests-implied-repos</dependency>
               <dependency>org.commonjava.aprox:aprox-ftests-autoprox</dependency>
               <dependency>org.commonjava.aprox:aprox-ftests-depgraph</dependency>
               <dependency>org.commonjava.aprox:aprox-ftests-promote</dependency>

--- a/embedders/savant/pom.xml
+++ b/embedders/savant/pom.xml
@@ -87,6 +87,10 @@
       <groupId>org.commonjava.aprox</groupId>
       <artifactId>aprox-promote-common</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.commonjava.aprox</groupId>
+      <artifactId>aprox-implied-repos-common</artifactId>
+    </dependency>
   </dependencies>
   
   <build>
@@ -122,6 +126,10 @@
         </dependency>
         <dependency>
           <groupId>org.commonjava.aprox</groupId>
+          <artifactId>aprox-ftests-implied-repos</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.commonjava.aprox</groupId>
           <artifactId>aprox-ftests-promote</artifactId>
         </dependency>
       </dependencies>
@@ -141,6 +149,7 @@
                     <dependency>org.commonjava.aprox:aprox-ftests-folo</dependency>
                     <dependency>org.commonjava.aprox:aprox-ftests-depgraph</dependency>
                     <dependency>org.commonjava.aprox:aprox-ftests-dot-maven</dependency>
+                    <dependency>org.commonjava.aprox:aprox-ftests-implied-repos</dependency>
                     <dependency>org.commonjava.aprox:aprox-ftests-promote</dependency>
                   </dependenciesToScan> 
                 </configuration>

--- a/models/core-java/src/main/java/org/commonjava/aprox/model/core/Group.java
+++ b/models/core-java/src/main/java/org/commonjava/aprox/model/core/Group.java
@@ -61,9 +61,19 @@ public class Group
 
     public synchronized boolean addConstituent( final StoreKey repository )
     {
+        if ( repository == null )
+        {
+            return false;
+        }
+
         if ( constituents == null )
         {
             constituents = new ArrayList<StoreKey>();
+        }
+
+        if ( !constituents.contains( repository ) )
+        {
+            return false;
         }
 
         return constituents.add( repository );

--- a/models/core-java/src/main/java/org/commonjava/aprox/model/core/Group.java
+++ b/models/core-java/src/main/java/org/commonjava/aprox/model/core/Group.java
@@ -71,7 +71,7 @@ public class Group
             constituents = new ArrayList<StoreKey>();
         }
 
-        if ( !constituents.contains( repository ) )
+        if ( constituents.contains( repository ) )
         {
             return false;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <slf4j-version>1.6.1</slf4j-version>
     <jbossas-version>7.1.1.Final</jbossas-version>
     <atlasVersion>0.14.0</atlasVersion>
-    <galleyVersion>0.8</galleyVersion>
+    <galleyVersion>0.8.1-SNAPSHOT</galleyVersion>
     <cartoVersion>0.9.1-SNAPSHOT</cartoVersion>
     <bomVersion>16</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
@@ -457,6 +457,16 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-promote-common</artifactId>
+        <version>0.20.1-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.aprox</groupId>
+        <artifactId>aprox-implied-repos-common</artifactId>
+        <version>0.20.1-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.aprox</groupId>
+        <artifactId>aprox-ftests-implied-repos</artifactId>
         <version>0.20.1-SNAPSHOT</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -466,6 +466,13 @@
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
+        <artifactId>aprox-implied-repos-common</artifactId>
+        <version>0.20.1-SNAPSHOT</version>
+        <type>tar.gz</type>
+        <classifier>confset</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-ftests-implied-repos</artifactId>
         <version>0.20.1-SNAPSHOT</version>
       </dependency>

--- a/test/fixtures-core/src/main/java/org/commonjava/aprox/test/fixture/core/TestHttpServer.java
+++ b/test/fixtures-core/src/main/java/org/commonjava/aprox/test/fixture/core/TestHttpServer.java
@@ -107,6 +107,7 @@ public class TestHttpServer
         if ( server != null )
         {
             server.stop();
+            logger.info( "STOPPED Test HTTP Server on 127.0.0.1:" + port );
         }
     }
 
@@ -137,6 +138,7 @@ public class TestHttpServer
                          .build();
 
         server.start();
+        logger.info( "STARTED Test HTTP Server on 127.0.0.1:" + port );
     }
 
     public static final class ExpectationServlet


### PR DESCRIPTION
These are repos that are declared in POMs that get proxied. Normally Maven will incorporate these, but when using a mirror configuration Maven doesn't have control to add new repositories (they all get mirrored to the same location, unless you exempt them beforehand in the settings.xml).

Needs more functional tests, but the basics seem to be working.