### PR TITLE
config for snapshot repo skimming and fixing a couple bugs

### DIFF
--- a/addons/autoprox/common/src/main/java/org/commonjava/aprox/autoprox/data/AutoProxDataManagerDecorator.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/aprox/autoprox/data/AutoProxDataManagerDecorator.java
@@ -258,7 +258,7 @@ public abstract class AutoProxDataManagerDecorator
                     }
 
                     final RemoteRepository remote = repo;
-                    dataManager.storeRemoteRepository( remote, new ChangeSummary( ChangeSummary.SYSTEM_USER,
+                    dataManager.storeArtifactStore( remote, new ChangeSummary( ChangeSummary.SYSTEM_USER,
                                                                                   "AUTOPROX: Creating remote repository for: '"
                                                                                       + name + "'" ) );
                 }
@@ -305,7 +305,7 @@ public abstract class AutoProxDataManagerDecorator
             if ( repo != null )
             {
                 final HostedRepository hosted = repo;
-                dataManager.storeHostedRepository( hosted, new ChangeSummary( ChangeSummary.SYSTEM_USER,
+                dataManager.storeArtifactStore( hosted, new ChangeSummary( ChangeSummary.SYSTEM_USER,
                                                                               "AUTOPROX: Creating remote repository for: '"
                                                                                   + name + "'" ) );
             }

--- a/addons/autoprox/common/src/test/java/org/commonjava/aprox/autoprox/fixture/TestAutoProxyDataManager.java
+++ b/addons/autoprox/common/src/test/java/org/commonjava/aprox/autoprox/fixture/TestAutoProxyDataManager.java
@@ -124,50 +124,6 @@ public class TestAutoProxyDataManager
     }
 
     @Override
-    public boolean storeHostedRepository( final HostedRepository deploy, final ChangeSummary summary )
-        throws AproxDataException
-    {
-        return delegate.storeHostedRepository( deploy, summary );
-    }
-
-    @Override
-    public boolean storeHostedRepository( final HostedRepository deploy, final ChangeSummary summary,
-                                          final boolean skipIfExists )
-        throws AproxDataException
-    {
-        return delegate.storeHostedRepository( deploy, summary, skipIfExists );
-    }
-
-    @Override
-    public boolean storeRemoteRepository( final RemoteRepository proxy, final ChangeSummary summary )
-        throws AproxDataException
-    {
-        return delegate.storeRemoteRepository( proxy, summary );
-    }
-
-    @Override
-    public boolean storeRemoteRepository( final RemoteRepository repository, final ChangeSummary summary,
-                                          final boolean skipIfExists )
-        throws AproxDataException
-    {
-        return delegate.storeRemoteRepository( repository, summary, skipIfExists );
-    }
-
-    @Override
-    public boolean storeGroup( final Group group, final ChangeSummary summary )
-        throws AproxDataException
-    {
-        return delegate.storeGroup( group, summary );
-    }
-
-    @Override
-    public boolean storeGroup( final Group group, final ChangeSummary summary, final boolean skipIfExists )
-        throws AproxDataException
-    {
-        return delegate.storeGroup( group, summary, skipIfExists );
-    }
-
-    @Override
     public boolean storeArtifactStore( final ArtifactStore key, final ChangeSummary summary )
         throws AproxDataException
     {
@@ -179,6 +135,14 @@ public class TestAutoProxyDataManager
         throws AproxDataException
     {
         return delegate.storeArtifactStore( key, summary, skipIfExists );
+    }
+
+    @Override
+    public boolean storeArtifactStore( final ArtifactStore key, final ChangeSummary summary,
+                                       final boolean skipIfExists, final boolean fireEvents )
+        throws AproxDataException
+    {
+        return delegate.storeArtifactStore( key, summary, skipIfExists, fireEvents );
     }
 
     @Override
@@ -265,6 +229,12 @@ public class TestAutoProxyDataManager
     public RemoteRepository findRemoteRepository( final String url )
     {
         return delegate.findRemoteRepository( url );
+    }
+
+    @Override
+    public boolean isStarted()
+    {
+        return delegate.isStarted();
     }
 
 }

--- a/addons/implied-repos/client-java/src/main/java/org/commonjava/aprox/implrepo/client/ImpliedRepoClientModule.java
+++ b/addons/implied-repos/client-java/src/main/java/org/commonjava/aprox/implrepo/client/ImpliedRepoClientModule.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.implrepo.client;
 
 import java.util.ArrayList;

--- a/addons/implied-repos/common/src/main/conf/conf.d/implied-repos.conf
+++ b/addons/implied-repos/common/src/main/conf/conf.d/implied-repos.conf
@@ -14,3 +14,8 @@
 # safe to auto-remove them.
 #
 #enabled=false
+
+# By default, repositories that don't enable release artifacts (usually these are snapshot repos) are 
+# excluded from being implied.
+#
+#include.snapshots=false

--- a/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/change/ImpliedRepositoryDetector.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/change/ImpliedRepositoryDetector.java
@@ -15,11 +15,9 @@
  */
 package org.commonjava.aprox.implrepo.change;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -247,6 +245,12 @@ public class ImpliedRepositoryDetector
 
             for ( final RepositoryView repo : repos )
             {
+                if ( !config.isIncludeSnapshotRepos() && !repo.isReleasesEnabled() )
+                {
+                    logger.debug( "Discarding snapshot repository: {}", repo );
+                    continue;
+                }
+
                 logger.debug( "Detected POM-declared repository: {}", repo );
                 RemoteRepository rr = storeManager.findRemoteRepository( repo.getUrl() );
                 if ( rr == null )
@@ -291,10 +295,10 @@ public class ImpliedRepositoryDetector
         return repo.getId();
     }
 
-    private String formatNow()
-    {
-        return new SimpleDateFormat( "yyyyMMdd_HHmm" ).format( new Date() );
-    }
+    //    private String formatNow()
+    //    {
+    //        return new SimpleDateFormat( "yyyyMMdd_HHmm" ).format( new Date() );
+    //    }
 
     public class ImplicationsJob
     {

--- a/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/conf/ImpliedRepoConfig.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/conf/ImpliedRepoConfig.java
@@ -65,7 +65,11 @@ public class ImpliedRepoConfig
 
     public static final boolean DEFAULT_ENABLED = false;
 
+    public static final boolean DEFAULT_INCLUDE_SNAPSHOT_REPOS = false;
+
     private Boolean enabled;
+
+    private Boolean includeSnapshotRepos;
 
     public ImpliedRepoConfig()
     {
@@ -80,6 +84,17 @@ public class ImpliedRepoConfig
     public void setEnabled( final Boolean enabled )
     {
         this.enabled = enabled;
+    }
+
+    public boolean isIncludeSnapshotRepos()
+    {
+        return includeSnapshotRepos == null ? DEFAULT_INCLUDE_SNAPSHOT_REPOS : includeSnapshotRepos;
+    }
+
+    @ConfigName( "include.snapshots" )
+    public void setIncludeSnapshotRepos( final Boolean includeSnapshotRepos )
+    {
+        this.includeSnapshotRepos = includeSnapshotRepos;
     }
 
     @javax.enterprise.context.ApplicationScoped

--- a/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/inject/ImpliedRepoProvider.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/inject/ImpliedRepoProvider.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.implrepo.inject;
 
 import javax.annotation.PostConstruct;

--- a/addons/implied-repos/common/src/main/resources/default-implied-repos.conf
+++ b/addons/implied-repos/common/src/main/resources/default-implied-repos.conf
@@ -14,3 +14,8 @@
 # safe to auto-remove them.
 #
 #enabled=false
+
+# By default, repositories that don't enable release artifacts (usually these are snapshot repos) are 
+# excluded from being implied.
+#
+#include.snapshots=false

--- a/addons/implied-repos/common/src/test/java/org/commonjava/aprox/implrepo/change/ImpliedRepoMaintainerTest.java
+++ b/addons/implied-repos/common/src/test/java/org/commonjava/aprox/implrepo/change/ImpliedRepoMaintainerTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.implrepo.change;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -48,13 +63,13 @@ public class ImpliedRepoMaintainerTest
         throws Exception
     {
         final Group g = new Group( "test" );
-        storeDataManager.storeGroup( g, summary );
+        storeDataManager.storeArtifactStore( g, summary );
 
         final RemoteRepository repo1 = new RemoteRepository( "one", "http://www.foo.com/repo" );
-        storeDataManager.storeRemoteRepository( repo1, summary );
+        storeDataManager.storeArtifactStore( repo1, summary );
 
         final RemoteRepository repo2 = new RemoteRepository( "one", "http://www.foo.com/repo" );
-        storeDataManager.storeRemoteRepository( repo2, summary );
+        storeDataManager.storeArtifactStore( repo2, summary );
 
         metadataManager.addImpliedMetadata( repo1, Arrays.<ArtifactStore> asList( repo2 ) );
 
@@ -72,13 +87,13 @@ public class ImpliedRepoMaintainerTest
         throws Exception
     {
         final Group g = new Group( "test" );
-        storeDataManager.storeGroup( g, summary );
+        storeDataManager.storeArtifactStore( g, summary );
 
         final RemoteRepository repo1 = new RemoteRepository( "one", "http://www.foo.com/repo" );
-        storeDataManager.storeRemoteRepository( repo1, summary );
+        storeDataManager.storeArtifactStore( repo1, summary );
 
         final RemoteRepository repo2 = new RemoteRepository( "one", "http://www.foo.com/repo" );
-        storeDataManager.storeRemoteRepository( repo2, summary );
+        storeDataManager.storeArtifactStore( repo2, summary );
 
         metadataManager.addImpliedMetadata( repo1, Arrays.<ArtifactStore> asList( repo2 ) );
 

--- a/addons/implied-repos/common/src/test/java/org/commonjava/aprox/implrepo/change/ImpliedRepositoryDetectorTest.java
+++ b/addons/implied-repos/common/src/test/java/org/commonjava/aprox/implrepo/change/ImpliedRepositoryDetectorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.implrepo.change;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -68,8 +83,8 @@ public class ImpliedRepositoryDetectorTest
         remote = new RemoteRepository( "test", "http://www.foo.com/repo" );
         group = new Group( "group", remote.getKey() );
 
-        storeManager.storeRemoteRepository( remote, summary );
-        storeManager.storeGroup( group, summary );
+        storeManager.storeArtifactStore( remote, summary );
+        storeManager.storeArtifactStore( group, summary );
     }
 
     @Test

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/aprox/implrepo/maint/CreateGroupWithMemberImplicationsTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/aprox/implrepo/maint/CreateGroupWithMemberImplicationsTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.implrepo.maint;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/api/src/main/java/org/commonjava/aprox/change/event/AproxLifecycleEvent.java
+++ b/api/src/main/java/org/commonjava/aprox/change/event/AproxLifecycleEvent.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.aprox.change.event;
+
+public class AproxLifecycleEvent
+{
+
+    public enum Type
+    {
+        started;
+    }
+
+    private final Type type;
+
+    public AproxLifecycleEvent( final Type type )
+    {
+        this.type = type;
+    }
+
+    public Type getType()
+    {
+        return type;
+    }
+
+}

--- a/api/src/main/java/org/commonjava/aprox/data/StoreDataManager.java
+++ b/api/src/main/java/org/commonjava/aprox/data/StoreDataManager.java
@@ -123,50 +123,6 @@ public interface StoreDataManager
         throws AproxDataException;
 
     /**
-     * Store a modified or new {@link HostedRepository} instance. This is equivalent to 
-     * {@link StoreDataManager#storeHostedRepository(HostedRepository, boolean)} with skip flag <code>false</code>
-     */
-    boolean storeHostedRepository( final HostedRepository deploy, final ChangeSummary summary )
-        throws AproxDataException;
-
-    /**
-     * Store a modified or new {@link HostedRepository} instance. If the store already exists, and <code>skipIfExists</code> is true, abort the
-     * operation.
-     */
-    boolean storeHostedRepository( final HostedRepository deploy, final ChangeSummary summary,
-                                   final boolean skipIfExists )
-        throws AproxDataException;
-
-    /**
-     * Store a modified or new {@link RemoteRepository} instance. This is equivalent to 
-     * {@link StoreDataManager#storeRemoteRepository(RemoteRepository, boolean)} with skip flag <code>false</code>
-     */
-    boolean storeRemoteRepository( final RemoteRepository proxy, final ChangeSummary summary )
-        throws AproxDataException;
-
-    /**
-     * Store a modified or new {@link RemoteRepository} instance. If the store already exists, and <code>skipIfExists</code> is true, abort the
-     * operation.
-     */
-    boolean storeRemoteRepository( final RemoteRepository repository, final ChangeSummary summary,
-                                   final boolean skipIfExists )
-        throws AproxDataException;
-
-    /**
-     * Store a modified or new {@link Group} instance. This is equivalent to 
-     * {@link StoreDataManager#storeGroup(Group, boolean)} with skip flag <code>false</code>
-     */
-    boolean storeGroup( final Group group, final ChangeSummary summary )
-        throws AproxDataException;
-
-    /**
-     * Store a modified or new {@link Group} instance. If the store already exists, and <code>skipIfExists</code> is true, abort the
-     * operation.
-     */
-    boolean storeGroup( final Group group, final ChangeSummary summary, final boolean skipIfExists )
-        throws AproxDataException;
-
-    /**
      * Store a modified or new {@link ArtifactStore} instance. This is equivalent to 
      * {@link StoreDataManager#storeArtifactStore(ArtifactStore, boolean)} with skip flag <code>false</code>
      */
@@ -178,6 +134,13 @@ public interface StoreDataManager
      * operation.
      */
     boolean storeArtifactStore( ArtifactStore key, final ChangeSummary summary, boolean skipIfExists )
+        throws AproxDataException;
+
+    /**
+     * Store a modified or new {@link ArtifactStore} instance. If the store already exists, and <code>skipIfExists</code> is true, abort the
+     * operation.
+     */
+    boolean storeArtifactStore( ArtifactStore key, final ChangeSummary summary, boolean skipIfExists, boolean fireEvents )
         throws AproxDataException;
 
     /**
@@ -269,5 +232,10 @@ public interface StoreDataManager
      * Find a remote repository with a URL that matches the given one, and return it...or null.
      */
     RemoteRepository findRemoteRepository( String url );
+
+    /**
+     * Return true once any post-construction code runs.
+     */
+    boolean isStarted();
 
 }

--- a/boot/jaxrs/src/main/java/org/commonjava/aprox/boot/jaxrs/JaxRsBooter.java
+++ b/boot/jaxrs/src/main/java/org/commonjava/aprox/boot/jaxrs/JaxRsBooter.java
@@ -20,6 +20,9 @@ import io.undertow.servlet.Servlets;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.DeploymentManager;
 
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.lang.reflect.InvocationTargetException;
+
 import javax.enterprise.inject.spi.BeanManager;
 import javax.servlet.ServletException;
 
@@ -45,6 +48,31 @@ public class JaxRsBooter
 {
     public static void main( final String[] args )
     {
+        Thread.currentThread()
+              .setUncaughtExceptionHandler( new UncaughtExceptionHandler()
+              {
+                  @Override
+                  public void uncaughtException( final Thread thread, final Throwable error )
+                  {
+                      if ( error instanceof InvocationTargetException )
+                      {
+                          final InvocationTargetException ite = (InvocationTargetException) error;
+                          System.err.println( "In: " + thread.getName() + "(" + thread.getId()
+                              + "), caught InvocationTargetException:" );
+                          ite.getTargetException()
+                             .printStackTrace();
+
+                          System.err.println( "...via:" );
+                          error.printStackTrace();
+                      }
+                      else
+                      {
+                          System.err.println( "In: " + thread.getName() + "(" + thread.getId() + ") Uncaught error:" );
+                          error.printStackTrace();
+                      }
+                  }
+              } );
+
         BootOptions boot;
         try
         {

--- a/core/src/main/java/org/commonjava/aprox/core/change/GroupConsistencyListener.java
+++ b/core/src/main/java/org/commonjava/aprox/core/change/GroupConsistencyListener.java
@@ -51,9 +51,10 @@ public class GroupConsistencyListener
             for ( final Group group : groups )
             {
                 group.removeConstituent( key );
-                proxyDataManager.storeGroup( group, new ChangeSummary( ChangeSummary.SYSTEM_USER,
+                proxyDataManager.storeArtifactStore( group, new ChangeSummary( ChangeSummary.SYSTEM_USER,
                                                                        "Auto-update groups containing: " + key
-                                                                           + " (to maintain consistency)" ) );
+                                                                                   + " (to maintain consistency)" ),
+                                                     false, false );
             }
 
             changeSync.setChanged();

--- a/core/src/main/java/org/commonjava/aprox/core/content/AbstractMergedContentGenerator.java
+++ b/core/src/main/java/org/commonjava/aprox/core/content/AbstractMergedContentGenerator.java
@@ -1,0 +1,119 @@
+package org.commonjava.aprox.core.content;
+
+import java.io.IOException;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.commonjava.aprox.AproxWorkflowException;
+import org.commonjava.aprox.content.AbstractContentGenerator;
+import org.commonjava.aprox.content.DownloadManager;
+import org.commonjava.aprox.core.content.group.GroupMergeHelper;
+import org.commonjava.aprox.data.AproxDataException;
+import org.commonjava.aprox.data.StoreDataManager;
+import org.commonjava.aprox.model.core.ArtifactStore;
+import org.commonjava.aprox.model.core.Group;
+import org.commonjava.aprox.model.core.StoreType;
+import org.commonjava.maven.galley.model.Transfer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractMergedContentGenerator
+    extends AbstractContentGenerator
+{
+    protected final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    protected DownloadManager fileManager;
+
+    @Inject
+    protected StoreDataManager storeManager;
+
+    @Inject
+    protected GroupMergeHelper helper;
+
+    protected AbstractMergedContentGenerator()
+    {
+    }
+
+    protected AbstractMergedContentGenerator( final DownloadManager fileManager, final StoreDataManager storeManager,
+                                              final GroupMergeHelper helper )
+    {
+        this.fileManager = fileManager;
+        this.storeManager = storeManager;
+        this.helper = helper;
+    }
+
+    @Override
+    public final void handleContentDeletion( final ArtifactStore store, final String path )
+        throws AproxWorkflowException
+    {
+        if ( path.endsWith( getMergedMetadataName() ) )
+        {
+            clearAllMerged( store, path );
+        }
+    }
+
+    @Override
+    public final void handleContentStorage( final ArtifactStore store, final String path, final Transfer result )
+        throws AproxWorkflowException
+    {
+        if ( path.endsWith( getMergedMetadataName() ) )
+        {
+            clearAllMerged( store, path );
+        }
+    }
+
+    protected abstract String getMergedMetadataName();
+
+    protected void clearAllMerged( final ArtifactStore store, final String path )
+        throws AproxWorkflowException
+    {
+        if ( StoreType.group == store.getKey()
+                                     .getType() )
+        {
+            final Group group = (Group) store;
+            clearMergedFile( group, path );
+        }
+
+        try
+        {
+            final Set<Group> groups = storeManager.getGroupsContaining( store.getKey() );
+            if ( groups != null )
+            {
+                for ( final Group group : groups )
+                {
+                    clearMergedFile( group, path );
+                }
+            }
+        }
+        catch ( final AproxDataException e )
+        {
+            throw new AproxWorkflowException(
+
+            "Failed to lookup groups whose membership contains: {} (to trigger re-generation on demand: {}. Error: {}",
+                                              e, store.getKey(), path, e.getMessage() );
+        }
+    }
+
+    protected void clearMergedFile( final Group group, final String path )
+        throws AproxWorkflowException
+    {
+        // delete so it'll be recomputed.
+        final Transfer target = fileManager.getStorageReference( group, path );
+        try
+        {
+            logger.debug( "Deleting merged file: {}", target );
+            target.delete();
+            helper.deleteChecksumsAndMergeInfo( group, path );
+        }
+        catch ( final IOException e )
+        {
+            throw new AproxWorkflowException(
+
+            "Failed to delete generated file (to allow re-generation on demand: {}. Error: {}", e,
+                                              target.getFullPath(), e.getMessage() );
+        }
+    }
+
+}

--- a/core/src/main/java/org/commonjava/aprox/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/aprox/core/content/DefaultContentManager.java
@@ -256,7 +256,9 @@ public class DefaultContentManager
             {
                 final List<ArtifactStore> allMembers = storeManager.getOrderedConcreteStoresInGroup( store.getName() );
 
-                return store( allMembers, path, stream, op );
+                final Transfer txfr = store( allMembers, path, stream, op );
+                logger.info( "Stored: {} for group: {} in: {}", path, store.getKey(), txfr );
+                return txfr;
             }
             catch ( final AproxDataException e )
             {
@@ -266,6 +268,7 @@ public class DefaultContentManager
         }
 
         final Transfer txfr = downloadManager.store( store, path, stream, op );
+        logger.info( "Stored: {} for: {} in: {}", path, store.getKey(), txfr );
         if ( txfr != null )
         {
             final KeyedLocation kl = (KeyedLocation) txfr.getLocation();
@@ -319,6 +322,7 @@ public class DefaultContentManager
 
             for ( final ContentGenerator generator : contentGenerators )
             {
+                logger.info( "{} Handling content storage of: {} in: {}", generator, path, transferStore.getKey() );
                 generator.handleContentStorage( transferStore, path, txfr );
             }
         }

--- a/core/src/main/java/org/commonjava/aprox/core/content/group/GroupMergeHelper.java
+++ b/core/src/main/java/org/commonjava/aprox/core/content/group/GroupMergeHelper.java
@@ -65,16 +65,19 @@ public class GroupMergeHelper
 
         if ( targetSha != null )
         {
+            logger.debug( "Deleting: {}", targetSha );
             targetSha.delete();
         }
 
         if ( targetMd5 != null )
         {
+            logger.debug( "Deleting: {}", targetMd5 );
             targetMd5.delete();
         }
 
         if ( targetInfo != null )
         {
+            logger.debug( "Deleting: {}", targetInfo );
             targetInfo.delete();
         }
     }

--- a/core/src/main/java/org/commonjava/aprox/core/ctl/ReplicationController.java
+++ b/core/src/main/java/org/commonjava/aprox/core/ctl/ReplicationController.java
@@ -133,7 +133,7 @@ public class ReplicationController
                                 final RemoteRepository repo = new RemoteRepository( key, view.getResourceUri() );
                                 setProxyAttributes( repo, action );
 
-                                data.storeRemoteRepository( repo, new ChangeSummary( user,
+                                data.storeArtifactStore( repo, new ChangeSummary( user,
                                                                                      "REPLICATION: Proxying remote aprox repository: "
                                                                                          + view.getResourceUri() ) );
                                 replicated.add( repo.getKey() );

--- a/core/src/main/java/org/commonjava/aprox/core/data/StoreDataSetupAction.java
+++ b/core/src/main/java/org/commonjava/aprox/core/data/StoreDataSetupAction.java
@@ -69,7 +69,7 @@ public class StoreDataSetupAction
                 final RemoteRepository central =
                     new RemoteRepository( "central", "http://repo.maven.apache.org/maven2/" );
                 central.setCacheTimeoutSeconds( 86400 );
-                storeManager.storeRemoteRepository( central, summary, true );
+                storeManager.storeArtifactStore( central, summary, true, true );
                 changed = true;
             }
 
@@ -80,7 +80,7 @@ public class StoreDataSetupAction
                 local.setAllowSnapshots( true );
                 local.setSnapshotTimeoutSeconds( 86400 );
 
-                storeManager.storeHostedRepository( local, summary, true );
+                storeManager.storeArtifactStore( local, summary, true, true );
                 changed = true;
             }
 
@@ -90,7 +90,7 @@ public class StoreDataSetupAction
                 pub.addConstituent( new StoreKey( StoreType.remote, "central" ) );
                 pub.addConstituent( new StoreKey( StoreType.hosted, "local-deployments" ) );
 
-                storeManager.storeGroup( pub, summary, true );
+                storeManager.storeArtifactStore( pub, summary, true, true );
                 changed = true;
             }
         }

--- a/core/src/main/java/org/commonjava/aprox/core/expire/TimeoutEventListener.java
+++ b/core/src/main/java/org/commonjava/aprox/core/expire/TimeoutEventListener.java
@@ -19,7 +19,6 @@ import static org.commonjava.aprox.util.LocationUtils.getKey;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.Executor;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
@@ -29,15 +28,15 @@ import org.commonjava.aprox.AproxWorkflowException;
 import org.commonjava.aprox.change.event.AbstractStoreDeleteEvent;
 import org.commonjava.aprox.change.event.ArtifactStorePostUpdateEvent;
 import org.commonjava.aprox.change.event.ArtifactStoreUpdateType;
-import org.commonjava.aprox.content.DownloadManager;
+import org.commonjava.aprox.content.ContentManager;
+import org.commonjava.aprox.data.AproxDataException;
+import org.commonjava.aprox.data.StoreDataManager;
 import org.commonjava.aprox.model.core.ArtifactStore;
 import org.commonjava.aprox.model.core.HostedRepository;
 import org.commonjava.aprox.model.core.RemoteRepository;
 import org.commonjava.aprox.model.core.StoreKey;
 import org.commonjava.aprox.model.core.StoreType;
 import org.commonjava.aprox.model.core.io.AproxObjectMapper;
-import org.commonjava.cdi.util.weft.ExecutorConfig;
-import org.commonjava.maven.atlas.ident.util.ArtifactPathInfo;
 import org.commonjava.maven.galley.event.FileAccessEvent;
 import org.commonjava.maven.galley.event.FileDeletionEvent;
 import org.commonjava.maven.galley.event.FileStorageEvent;
@@ -55,14 +54,17 @@ public class TimeoutEventListener
     private ScheduleManager scheduleManager;
 
     @Inject
-    private DownloadManager fileManager;
+    private ContentManager fileManager;
+
+    @Inject
+    private StoreDataManager storeManager;
 
     @Inject
     private AproxObjectMapper objectMapper;
 
-    @Inject
-    @ExecutorConfig( daemon = true, priority = 7, named = "aprox-events" )
-    private Executor executor;
+    //    @Inject
+    //    @ExecutorConfig( daemon = true, priority = 7, named = "aprox-events" )
+    //    private Executor executor;
 
     public void onExpirationEvent( @Observes final SchedulerEvent event )
     {
@@ -72,281 +74,215 @@ public class TimeoutEventListener
             return;
         }
 
-        executor.execute( new Runnable()
+        ContentExpiration expiration;
+        try
         {
-            @Override
-            public void run()
+            expiration = objectMapper.readValue( event.getPayload(), ContentExpiration.class );
+        }
+        catch ( final IOException e )
+        {
+            logger.error( "Failed to read ContentExpiration from event payload.", e );
+            return;
+        }
+
+        final StoreKey key = expiration.getKey();
+        final String path = expiration.getPath();
+
+        boolean deleted = false;
+        try
+        {
+            final ArtifactStore store = storeManager.getArtifactStore( key );
+
+            logger.info( "[EXPIRED; DELETE] {}:{}", key, path );
+            deleted = fileManager.delete( store, path );
+        }
+        catch ( final AproxWorkflowException | AproxDataException e )
+        {
+            logger.error( String.format( "Failed to delete expired file for: %s, %s. Reason: %s", key, path,
+                                         e.getMessage() ), e );
+
+            return;
+        }
+
+        if ( deleted )
+        {
+            try
             {
-                ContentExpiration expiration;
-                try
-                {
-                    expiration = objectMapper.readValue( event.getPayload(), ContentExpiration.class );
-                }
-                catch ( final IOException e )
-                {
-                    logger.error( "Failed to read ContentExpiration from event payload.", e );
-                    return;
-                }
-
-                final StoreKey key = expiration.getKey();
-                final String path = expiration.getPath();
-
-                Transfer toDelete;
-                try
-                {
-                    toDelete = fileManager.getStorageReference( key, path );
-                }
-                catch ( final AproxWorkflowException e )
-                {
-                    logger.error( String.format( "Failed to delete expired file for: %s, %s. Reason: %s", key, path,
-                                                 e.getMessage() ), e );
-
-                    return;
-                }
-
-                if ( toDelete.exists() )
-                {
-                    try
-                    {
-                        logger.info( "[EXPIRED; DELETE] {}", toDelete );
-                        toDelete.delete();
-
-                        scheduleManager.deleteJob( scheduleManager.groupName( key, ScheduleManager.CONTENT_JOB_TYPE ),
-                                                   path );
-
-                        scheduleManager.cleanMetadata( key, path );
-                    }
-                    catch ( final IOException e )
-                    {
-                        logger.error( String.format( "Failed to delete expired file: %s. Reason: %s",
-                                                     toDelete.getFullPath(), e.getMessage() ), e );
-                    }
-                    catch ( final AproxSchedulerException e )
-                    {
-                        logger.error( String.format( "Failed to clean metadata related to expired file: %s. Reason: %s",
-                                                     toDelete.getFullPath(), e.getMessage() ), e );
-                    }
-
-                }
-
-                final ArtifactPathInfo pathInfo = ArtifactPathInfo.parse( path );
-                if ( pathInfo == null )
-                {
-                    return;
-                }
-
-                if ( pathInfo.isSnapshot() )
-                {
-                    scheduleManager.updateSnapshotVersions( key, path );
-                }
+                scheduleManager.deleteJob( scheduleManager.groupName( key, ScheduleManager.CONTENT_JOB_TYPE ), path );
             }
-        } );
+            catch ( final AproxSchedulerException e )
+            {
+                logger.error( String.format( "Failed to clean metadata related to expired: %s in: %s. Reason: %s",
+                                             path, key, e.getMessage() ), e );
+            }
+
+        }
     }
 
     public void onFileStorageEvent( @Observes final FileStorageEvent event )
     {
-        executor.execute( new Runnable()
+        final StoreKey key = getKey( event );
+        if ( key == null )
         {
-            @Override
-            public void run()
+            return;
+        }
+
+        final Transfer transfer = event.getTransfer();
+        final TransferOperation type = event.getType();
+
+        switch ( type )
+        {
+            case UPLOAD:
             {
-                final StoreKey key = getKey( event );
-                if ( key == null )
+                try
                 {
-                    return;
+                    scheduleManager.setSnapshotTimeouts( key, transfer.getPath() );
+                }
+                catch ( final AproxSchedulerException e )
+                {
+                    logger.error( "Failed to clean up metadata / set snapshot timeouts related to: " + transfer, e );
                 }
 
-                final Transfer transfer = event.getTransfer();
-                final TransferOperation type = event.getType();
-
-                switch ( type )
-                {
-                    case UPLOAD:
-                    {
-                        try
-                        {
-                            scheduleManager.cleanMetadata( key, transfer.getPath() );
-                            scheduleManager.setSnapshotTimeouts( key, transfer.getPath() );
-                        }
-                        catch ( final AproxSchedulerException e )
-                        {
-                            logger.error( "Failed to clean up metadata / set snapshot timeouts related to: " + transfer,
-                                          e );
-                        }
-
-                        break;
-                    }
-                    case DOWNLOAD:
-                    {
-                        try
-                        {
-                            scheduleManager.cleanMetadata( key, transfer.getPath() );
-                            scheduleManager.setProxyTimeouts( key, transfer.getPath() );
-                        }
-                        catch ( final AproxSchedulerException e )
-                        {
-                            logger.error( "Failed to clean up metadata / set proxy-cache timeouts related to: "
-                                + transfer, e );
-                        }
-
-                        break;
-                    }
-                    default:
-                    {
-                        break;
-                    }
-                }
+                break;
             }
-        } );
+            case DOWNLOAD:
+            {
+                try
+                {
+                    scheduleManager.setProxyTimeouts( key, transfer.getPath() );
+                }
+                catch ( final AproxSchedulerException e )
+                {
+                    logger.error( "Failed to clean up metadata / set proxy-cache timeouts related to: " + transfer, e );
+                }
+
+                break;
+            }
+            default:
+            {
+                break;
+            }
+        }
     }
 
     public void onFileAccessEvent( @Observes final FileAccessEvent event )
     {
-        executor.execute( new Runnable()
+        final StoreKey key = getKey( event );
+        if ( key != null )
         {
-            @Override
-            public void run()
-            {
-                final StoreKey key = getKey( event );
-                if ( key != null )
-                {
-                    final Transfer transfer = event.getTransfer();
-                    final StoreType type = key.getType();
+            final Transfer transfer = event.getTransfer();
+            final StoreType type = key.getType();
 
-                    if ( type == StoreType.hosted )
-                    {
-                        try
-                        {
-                            scheduleManager.setSnapshotTimeouts( key, transfer.getPath() );
-                        }
-                        catch ( final AproxSchedulerException e )
-                        {
-                            logger.error( "Failed to set snapshot timeouts related to: " + transfer, e );
-                        }
-                    }
-                    else if ( type == StoreType.remote )
-                    {
-                        try
-                        {
-                            scheduleManager.setProxyTimeouts( key, transfer.getPath() );
-                        }
-                        catch ( final AproxSchedulerException e )
-                        {
-                            logger.error( "Failed to set proxy-cache timeouts related to: " + transfer, e );
-                        }
-                    }
+            if ( type == StoreType.hosted )
+            {
+                try
+                {
+                    scheduleManager.setSnapshotTimeouts( key, transfer.getPath() );
+                }
+                catch ( final AproxSchedulerException e )
+                {
+                    logger.error( "Failed to set snapshot timeouts related to: " + transfer, e );
                 }
             }
-        } );
+            else if ( type == StoreType.remote )
+            {
+                try
+                {
+                    scheduleManager.setProxyTimeouts( key, transfer.getPath() );
+                }
+                catch ( final AproxSchedulerException e )
+                {
+                    logger.error( "Failed to set proxy-cache timeouts related to: " + transfer, e );
+                }
+            }
+        }
     }
 
     public void onFileDeletionEvent( @Observes final FileDeletionEvent event )
     {
-        executor.execute( new Runnable()
+        final StoreKey key = getKey( event );
+        if ( key != null )
         {
-            @Override
-            public void run()
+            try
             {
-                final StoreKey key = getKey( event );
-                if ( key != null )
-                {
-                    try
-                    {
-                        scheduleManager.cancel( new StoreKeyMatcher( key, ScheduleManager.CONTENT_JOB_TYPE ),
-                                                event.getTransfer()
-                                                     .getPath() );
-                    }
-                    catch ( final AproxSchedulerException e )
-                    {
-                        logger.error( "Failed to cancel content-expiration timeout related to: " + event.getTransfer(),
-                                      e );
-                    }
-                }
+                scheduleManager.cancel( new StoreKeyMatcher( key, ScheduleManager.CONTENT_JOB_TYPE ),
+                                        event.getTransfer()
+                                             .getPath() );
             }
-        } );
+            catch ( final AproxSchedulerException e )
+            {
+                logger.error( "Failed to cancel content-expiration timeout related to: " + event.getTransfer(), e );
+            }
+        }
     }
 
     public void onStoreUpdate( @Observes final ArtifactStorePostUpdateEvent event )
     {
-        executor.execute( new Runnable()
+        final ArtifactStoreUpdateType eventType = event.getType();
+        if ( eventType == ArtifactStoreUpdateType.UPDATE )
         {
-            @Override
-            public void run()
+            for ( final ArtifactStore store : event )
             {
-                final ArtifactStoreUpdateType eventType = event.getType();
-                if ( eventType == ArtifactStoreUpdateType.UPDATE )
+                final StoreKey key = store.getKey();
+                final StoreType type = key.getType();
+                if ( type == StoreType.hosted )
                 {
-                    for ( final ArtifactStore store : event )
+                    logger.info( "[ADJUST TIMEOUTS] Adjusting snapshot expirations in: %s", store.getKey() );
+                    try
                     {
-                        final StoreKey key = store.getKey();
-                        final StoreType type = key.getType();
-                        if ( type == StoreType.hosted )
-                        {
-                            //                    logger.info( "[ADJUST TIMEOUTS] Adjusting snapshot expirations in: %s", store.getKey() );
-                            try
-                            {
-                                scheduleManager.rescheduleSnapshotTimeouts( (HostedRepository) store );
-                            }
-                            catch ( final AproxSchedulerException e )
-                            {
-                                logger.error( "Failed to update snapshot timeouts in: " + store.getKey(), e );
-                            }
-                        }
-                        else if ( type == StoreType.remote )
-                        {
-                            //                    logger.info( "[ADJUST TIMEOUTS] Adjusting proxied-file expirations in: %s", store.getKey() );
-                            try
-                            {
-                                scheduleManager.rescheduleProxyTimeouts( (RemoteRepository) store );
-                            }
-                            catch ( final AproxSchedulerException e )
-                            {
-                                logger.error( "Failed to update proxy-cache timeouts in: " + store.getKey(), e );
-                            }
-                        }
+                        scheduleManager.rescheduleSnapshotTimeouts( (HostedRepository) store );
+                    }
+                    catch ( final AproxSchedulerException e )
+                    {
+                        logger.error( "Failed to update snapshot timeouts in: " + store.getKey(), e );
+                    }
+                }
+                else if ( type == StoreType.remote )
+                {
+                    logger.info( "[ADJUST TIMEOUTS] Adjusting proxied-file expirations in: %s", store.getKey() );
+                    try
+                    {
+                        scheduleManager.rescheduleProxyTimeouts( (RemoteRepository) store );
+                    }
+                    catch ( final AproxSchedulerException e )
+                    {
+                        logger.error( "Failed to update proxy-cache timeouts in: " + store.getKey(), e );
                     }
                 }
             }
-        } );
+        }
     }
 
     public void onStoreDeletion( @Observes final AbstractStoreDeleteEvent event )
     {
-        executor.execute( new Runnable()
+        for ( final Map.Entry<ArtifactStore, Transfer> storeRoot : event.getStoreRoots()
+                                                                        .entrySet() )
         {
-            @Override
-            public void run()
+            final StoreKey key = storeRoot.getKey()
+                                          .getKey();
+
+            final Transfer dir = storeRoot.getValue();
+
+            if ( dir.exists() && dir.isDirectory() )
             {
-                for ( final Map.Entry<ArtifactStore, Transfer> storeRoot : event.getStoreRoots()
-                                                                                .entrySet() )
+                try
                 {
-                    final StoreKey key = storeRoot.getKey()
-                                                  .getKey();
-
-                    final Transfer dir = storeRoot.getValue();
-
-                    if ( dir.exists() && dir.isDirectory() )
-                    {
-                        try
-                        {
-                            logger.info( "[STORE REMOVED; DELETE] {}", dir.getFullPath() );
-                            dir.delete();
-                            scheduleManager.cancelAll( new StoreKeyMatcher( key, ScheduleManager.CONTENT_JOB_TYPE ) );
-                        }
-                        catch ( final IOException e )
-                        {
-                            logger.error( String.format( "Failed to delete storage for deleted artifact store: %s (dir: %s). Error: %s",
-                                                         key, dir, e.getMessage() ), e );
-                        }
-                        catch ( final AproxSchedulerException e )
-                        {
-                            logger.error( String.format( "Failed to cancel file expirations for deleted artifact store: {} (dir: {}). Error: {}",
-                                                         key, dir, e.getMessage() ), e );
-                        }
-                    }
+                    logger.info( "[STORE REMOVED; DELETE] {}", dir.getFullPath() );
+                    dir.delete();
+                    scheduleManager.cancelAll( new StoreKeyMatcher( key, ScheduleManager.CONTENT_JOB_TYPE ) );
+                }
+                catch ( final IOException e )
+                {
+                    logger.error( String.format( "Failed to delete storage for deleted artifact store: %s (dir: %s). Error: %s",
+                                                 key, dir, e.getMessage() ), e );
+                }
+                catch ( final AproxSchedulerException e )
+                {
+                    logger.error( String.format( "Failed to cancel file expirations for deleted artifact store: {} (dir: {}). Error: {}",
+                                                 key, dir, e.getMessage() ), e );
                 }
             }
-        } );
+        }
     }
 
 }

--- a/core/src/test/java/org/commonjava/aprox/core/content/MavenMetadataGeneratorTest.java
+++ b/core/src/test/java/org/commonjava/aprox/core/content/MavenMetadataGeneratorTest.java
@@ -90,7 +90,7 @@ public class MavenMetadataGeneratorTest
         final MavenMetadataMerger merger = new MavenMetadataMerger();
         final GroupMergeHelper helper = new GroupMergeHelper( downloads );
 
-        generator = new MavenMetadataGenerator( downloads, xml, types, merger, helper );
+        generator = new MavenMetadataGenerator( downloads, stores, xml, types, merger, helper );
 
         metadataReader = new MavenMetadataReader( xml, locations, fixture.getMetadata(), fixture.getXpathManager() );
     }

--- a/core/src/test/java/org/commonjava/aprox/rest/util/PathRetrieverTest.java
+++ b/core/src/test/java/org/commonjava/aprox/rest/util/PathRetrieverTest.java
@@ -71,7 +71,7 @@ public class PathRetrieverTest
         throws Exception
     {
         final RemoteRepository repo = new RemoteRepository( "central", "http://repo.maven.apache.org/maven2/" );
-        data.storeRemoteRepository( repo, summary );
+        data.storeArtifactStore( repo, summary );
 
         final String path = "/org/apache/maven/maven-model/3.0.3/maven-model-3.0.3.pom";
 
@@ -88,8 +88,8 @@ public class PathRetrieverTest
         final RemoteRepository repo = new RemoteRepository( "dummy", "http://www.nowhere.com/" );
         final RemoteRepository repo2 = new RemoteRepository( "central", "http://repo.maven.apache.org/maven2/" );
 
-        data.storeRemoteRepository( repo, summary );
-        data.storeRemoteRepository( repo2, summary );
+        data.storeArtifactStore( repo, summary );
+        data.storeArtifactStore( repo2, summary );
 
         final String path = "/org/apache/maven/maven-model/3.0.3/maven-model-3.0.3.pom";
 

--- a/db/flat/src/main/java/org/commonjava/aprox/flat/data/LegacyDataMigrationAction.java
+++ b/db/flat/src/main/java/org/commonjava/aprox/flat/data/LegacyDataMigrationAction.java
@@ -109,13 +109,13 @@ public class LegacyDataMigrationAction
             final List<HostedRepository> hosted = data.getAllHostedRepositories();
             for ( final HostedRepository repo : hosted )
             {
-                data.storeHostedRepository( repo, summary );
+                data.storeArtifactStore( repo, summary, false, true );
             }
 
             final List<RemoteRepository> remotes = data.getAllRemoteRepositories();
             for ( final RemoteRepository repo : remotes )
             {
-                data.storeRemoteRepository( repo, summary );
+                data.storeArtifactStore( repo, summary, false, true );
             }
 
             data.reload();

--- a/db/flat/src/main/java/org/commonjava/aprox/flat/data/StoreWithTypeMigrationAction.java
+++ b/db/flat/src/main/java/org/commonjava/aprox/flat/data/StoreWithTypeMigrationAction.java
@@ -131,13 +131,13 @@ public class StoreWithTypeMigrationAction
             final List<HostedRepository> hosted = data.getAllHostedRepositories();
             for ( final HostedRepository repo : hosted )
             {
-                data.storeHostedRepository( repo, summary );
+                data.storeArtifactStore( repo, summary, false, true );
             }
 
             final List<RemoteRepository> remotes = data.getAllRemoteRepositories();
             for ( final RemoteRepository repo : remotes )
             {
-                data.storeRemoteRepository( repo, summary );
+                data.storeArtifactStore( repo, summary, false, true );
             }
 
             data.reload();

--- a/db/flat/src/test/java/org/commonjava/aprox/flat/data/DataFileStoreDataManagerTest.java
+++ b/db/flat/src/test/java/org/commonjava/aprox/flat/data/DataFileStoreDataManagerTest.java
@@ -62,7 +62,7 @@ public class DataFileStoreDataManagerTest
     {
         final String name = "foo";
         final boolean success =
-            mgr.storeRemoteRepository( new RemoteRepository( name, "http://www.foo.com/" ),
+            mgr.storeArtifactStore( new RemoteRepository( name, "http://www.foo.com/" ),
                                        new ChangeSummary( "test-user", "init" ) );
 
         assertThat( success, equalTo( true ) );

--- a/pom.xml
+++ b/pom.xml
@@ -913,7 +913,7 @@
       </modules>
     </profile>
     <profile>
-      <id>travis</id>
+      <id>ci</id>
       <properties>
         <test-forkCount>1</test-forkCount>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <webdavVersion>3.2.1</webdavVersion>
     <resteasyVersion>3.0.9.Final</resteasyVersion>
     <undertowVersion>1.1.2.Final</undertowVersion>
+    <partylineVersion>1.4-SNAPSHOT</partylineVersion>
     
     <test-forkCount>1C</test-forkCount>
     <test-redirectOutput>true</test-redirectOutput>
@@ -580,6 +581,13 @@
         <groupId>org.commonjava.maven.cartographer</groupId>
         <artifactId>cartographer</artifactId>
         <version>${cartoVersion}</version>
+      </dependency>
+      
+      <!-- override galley-cache-partyline dep -->
+      <dependency>
+        <groupId>org.commonjava.util.partyline</groupId>
+        <artifactId>partyline</artifactId>
+        <version>${partylineVersion}</version>
       </dependency>
       
       <dependency>

--- a/test/db/src/main/java/org/commonjava/aprox/core/data/GroupDataManagerTCK.java
+++ b/test/db/src/main/java/org/commonjava/aprox/core/data/GroupDataManagerTCK.java
@@ -63,9 +63,9 @@ public abstract class GroupDataManagerTCK
     {
         manager = getFixtureProvider().getDataManager();
 
-        manager.storeRemoteRepository( new RemoteRepository( "central", "http://repo1.maven.apache.org/maven2/" ),
+        manager.storeArtifactStore( new RemoteRepository( "central", "http://repo1.maven.apache.org/maven2/" ),
                                        summary );
-        manager.storeRemoteRepository( new RemoteRepository( "repo2", "http://repo1.maven.org/maven2/" ), summary );
+        manager.storeArtifactStore( new RemoteRepository( "repo2", "http://repo1.maven.org/maven2/" ), summary );
     }
 
     @Test
@@ -102,7 +102,7 @@ public abstract class GroupDataManagerTCK
     {
         for ( final Group group : groups )
         {
-            manager.storeGroup( group, summary );
+            manager.storeArtifactStore( group, summary );
         }
     }
 

--- a/travis-settings.xml
+++ b/travis-settings.xml
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <settings>
   <servers>
     <server>


### PR DESCRIPTION
* configure whether snapshot repos should be skimmed from POMs
* fixing stack overflow related to store update events fired while aprox initializes (reads from disk)
* fixing various eventing bugs and multiple half-assed solutions to merged metadata files and content timeouts