### PR TITLE
attempting to fix failing ftest by removing code to trim out '+tracki…

### DIFF
--- a/addons/depgraph/common/src/main/java/org/commonjava/aprox/depgraph/dto/WebOperationConfigDTO.java
+++ b/addons/depgraph/common/src/main/java/org/commonjava/aprox/depgraph/dto/WebOperationConfigDTO.java
@@ -41,6 +41,10 @@ public class WebOperationConfigDTO
 
     private Boolean localUrls;
 
+    private Boolean pathOnly;
+
+    private Boolean prependDownloading;
+
     public StoreKey getSource()
     {
         return source;
@@ -131,6 +135,26 @@ public class WebOperationConfigDTO
 
             setExcludedSourceLocations( excluded );
         }
+    }
+
+    public Boolean getPathOnly()
+    {
+        return pathOnly == null ? false : pathOnly;
+    }
+
+    public void setPathOnly( final Boolean pathOnly )
+    {
+        this.pathOnly = pathOnly;
+    }
+
+    public Boolean getPrependDownloading()
+    {
+        return prependDownloading == null ? false : prependDownloading;
+    }
+
+    public void setPrependDownloading( final Boolean prependDownloading )
+    {
+        this.prependDownloading = prependDownloading;
     }
 
 }

--- a/addons/depgraph/common/src/main/java/org/commonjava/aprox/depgraph/rest/RepositoryController.java
+++ b/addons/depgraph/common/src/main/java/org/commonjava/aprox/depgraph/rest/RepositoryController.java
@@ -287,7 +287,7 @@ public class RepositoryController
                 for ( final ConcreteResource item : items.values() )
                 {
                     logger.info( "Adding: '{}'", item );
-                    downLog.add( formatDownlogEntry( item, dto.getLocalUrls(), baseUri, uriFormatter ) );
+                    downLog.add( formatDownlogEntry( item, dto, baseUri, uriFormatter ) );
                 }
             }
         }
@@ -409,22 +409,50 @@ public class RepositoryController
         }
     }
 
-    private String formatDownlogEntry( final ConcreteResource item, final boolean localUrls, final String baseUri, final UriFormatter uriFormatter )
+    private String formatDownlogEntry( final ConcreteResource item, final WebOperationConfigDTO dto,
+                                       final String baseUri, final UriFormatter uriFormatter )
         throws MalformedURLException
     {
         final KeyedLocation kl = (KeyedLocation) item.getLocation();
         final StoreKey key = kl.getKey();
 
-        if ( localUrls || kl instanceof CacheOnlyLocation )
+        if ( dto.getPathOnly() )
+        {
+            if ( dto.getPrependDownloading() )
+            {
+                return "Downloading: " + item.getPath();
+            }
+            else
+            {
+                return item.getPath();
+            }
+        }
+
+        if ( dto.getLocalUrls() || kl instanceof CacheOnlyLocation )
         {
             final String uri = uriFormatter.formatAbsolutePathTo( baseUri, key.getType()
-                                                                              .singularEndpointName(), key.getName() );
-            return String.format( "Downloading: %s", uri );
+                                                               .singularEndpointName(), key.getName(), item.getPath() );
+            if ( dto.getPrependDownloading() )
+            {
+                return String.format( "Downloading: %s", uri );
+            }
+            else
+            {
+                return uri;
+            }
         }
         else
         {
-            return "Downloading: " + buildUrl( item.getLocation()
+            if ( dto.getPrependDownloading() )
+            {
+                return "Downloading: " + buildUrl( item.getLocation()
                                                    .getUri(), item.getPath() );
+            }
+            else
+            {
+                return buildUrl( item.getLocation()
+                                     .getUri(), item.getPath() );
+            }
         }
     }
 

--- a/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/handler/ProxyResponseWriter.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/handler/ProxyResponseWriter.java
@@ -202,10 +202,9 @@ public final class ProxyResponseWriter
                 }
                 case SUFFIX:
                 {
-                    String user = proxyUserPass.getUser();
+                    final String user = proxyUserPass.getUser();
                     if ( user.endsWith( TRACKED_USER_SUFFIX ) && user.length() > TRACKED_USER_SUFFIX.length() )
                     {
-                        user = user.substring( 0, user.length() - TRACKED_USER_SUFFIX.length() );
                         tk = new TrackingKey( user );
                     }
 

--- a/addons/httprox/ftests/src/main/java/org/commonjava/aprox/httprox/RetrievedPomInTrackingReportTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/aprox/httprox/RetrievedPomInTrackingReportTest.java
@@ -27,9 +27,7 @@ public class RetrievedPomInTrackingReportTest
     extends AbstractHttproxFunctionalTest
 {
 
-    private static final String TID = "user";
-
-    private static final String USER = TID + "+tracking";
+    private static final String USER = "user+tracking";
 
     private static final String PASS = "password";
 
@@ -65,7 +63,7 @@ public class RetrievedPomInTrackingReportTest
 
         final String repoName = "httprox_127-0-0-1";
         final TrackedContentRecord record = this.client.module( AproxFoloAdminClientModule.class )
-                                                       .getRawTrackingRecord( TID );
+                                                       .getRawTrackingRecord( USER );
         assertThat( record, notNullValue() );
 
         final Map<StoreKey, AffectedStoreRecord> affectedStores = record.getAffectedStores();


### PR DESCRIPTION
…ng' from proxy userid when tracking is enabled by suffix. It'll appear in the tracking id now, but that's not too bad to gain a little more consistency.