### PR TITLE
fix settings templates, implement blacklisting in implied-repos

### DIFF
--- a/addons/autoprox/common/src/main/java/org/commonjava/aprox/autoprox/data/AutoProxConstants.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/aprox/autoprox/data/AutoProxConstants.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.autoprox.data;
 
 public class AutoProxConstants

--- a/addons/dot-maven/common/src/main/data/templates/settings.xml.groovy
+++ b/addons/dot-maven/common/src/main/data/templates/settings.xml.groovy
@@ -1,18 +1,3 @@
-/**
- * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright (c) 2014 Red Hat, Inc..

--- a/addons/folo/common/src/main/java/org/commonjava/aprox/folo/change/FoloTrackingListener.java
+++ b/addons/folo/common/src/main/java/org/commonjava/aprox/folo/change/FoloTrackingListener.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.folo.change;
 
 import javax.enterprise.event.Observes;

--- a/addons/folo/common/src/main/java/org/commonjava/aprox/folo/ctl/FoloConstants.java
+++ b/addons/folo/common/src/main/java/org/commonjava/aprox/folo/ctl/FoloConstants.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.folo.ctl;
 
 public class FoloConstants

--- a/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/HttpProxy.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/HttpProxy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.httprox;
 
 import java.io.IOException;

--- a/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/conf/HttproxConfig.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/conf/HttproxConfig.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.httprox.conf;
 
 import java.io.File;

--- a/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/conf/TrackingType.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/conf/TrackingType.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.httprox.conf;
 
 public enum TrackingType

--- a/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/handler/ProxyRequestReader.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/handler/ProxyRequestReader.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.httprox.handler;
 
 import java.io.IOException;

--- a/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/handler/ProxyResponseWriter.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/handler/ProxyResponseWriter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.httprox.handler;
 
 import static org.commonjava.aprox.httprox.util.HttpProxyConstants.ALLOW_HEADER_VALUE;

--- a/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/util/HttpProxyConstants.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/util/HttpProxyConstants.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.httprox.util;
 
 import java.util.Arrays;

--- a/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/util/UserPass.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/util/UserPass.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.httprox.util;
 
 import java.util.List;

--- a/addons/httprox/common/src/test/java/org/commonjava/aprox/httprox/HttpProxyTest.java
+++ b/addons/httprox/common/src/test/java/org/commonjava/aprox/httprox/HttpProxyTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.httprox;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/addons/httprox/ftests/src/main/java/org/commonjava/aprox/httprox/AutoCreateRepoAndRetrievePomTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/aprox/httprox/AutoCreateRepoAndRetrievePomTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.httprox;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/addons/httprox/ftests/src/main/java/org/commonjava/aprox/httprox/Propagate404NotFoundTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/aprox/httprox/Propagate404NotFoundTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.httprox;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/addons/httprox/ftests/src/main/java/org/commonjava/aprox/httprox/Propagate500As502ErrorTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/aprox/httprox/Propagate500As502ErrorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.httprox;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/addons/httprox/ftests/src/main/java/org/commonjava/aprox/httprox/RetrievedPomInTrackingReportTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/aprox/httprox/RetrievedPomInTrackingReportTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.httprox;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/addons/implied-repos/common/src/main/conf/conf.d/implied-repos.conf
+++ b/addons/implied-repos/common/src/main/conf/conf.d/implied-repos.conf
@@ -19,3 +19,10 @@
 # excluded from being implied.
 #
 #include.snapshots=false
+
+# You can blacklist repositories from being implied using 'disabled' entries. These should contain
+# either the hostname or host:port.
+#
+# Disable Codehaus, since it's defunct.
+disable=snapshots.repository.codehaus.org
+disable=repository.codehaus.org

--- a/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/conf/ImpliedRepoConfig.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/conf/ImpliedRepoConfig.java
@@ -17,6 +17,7 @@ package org.commonjava.aprox.implrepo.conf;
 
 import java.io.File;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -186,6 +187,13 @@ public class ImpliedRepoConfig
     public Class<?> getConfigurationClass()
     {
         return getClass();
+    }
+
+    public boolean isBlacklisted( final String url )
+        throws MalformedURLException
+    {
+        final URL u = new URL( url );
+        return isBlacklisted( u );
     }
 
 }

--- a/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/conf/ImpliedRepoConfig.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/conf/ImpliedRepoConfig.java
@@ -23,24 +23,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Alternative;
-import javax.enterprise.inject.Default;
-import javax.enterprise.inject.Produces;
-import javax.inject.Named;
 
-import org.commonjava.aprox.conf.AbstractAproxFeatureConfig;
 import org.commonjava.aprox.conf.AbstractAproxMapConfig;
-import org.commonjava.aprox.conf.AproxConfigClassInfo;
 import org.commonjava.aprox.conf.AproxConfigInfo;
 import org.commonjava.web.config.ConfigurationException;
-import org.commonjava.web.config.annotation.SectionName;
 
-@SectionName( ImpliedRepoConfig.SECTION_NAME )
-@Alternative
-@Named
+@ApplicationScoped
 public class ImpliedRepoConfig
     extends AbstractAproxMapConfig
-    implements AproxConfigClassInfo
+//    implements AproxConfigClassInfo
 {
 
     public static final String SECTION_NAME = "implied-repos";
@@ -63,6 +54,7 @@ public class ImpliedRepoConfig
 
     public ImpliedRepoConfig()
     {
+        super( SECTION_NAME );
     }
 
     public boolean isEnabled()
@@ -144,30 +136,30 @@ public class ImpliedRepoConfig
         }
     }
 
-    @javax.enterprise.context.ApplicationScoped
-    public static class FeatureConfig
-        extends AbstractAproxFeatureConfig<ImpliedRepoConfig, ImpliedRepoConfig>
-    {
-        public FeatureConfig()
-        {
-            super( new ImpliedRepoConfig() );
-        }
-
-        @Produces
-        @Default
-        @ApplicationScoped
-        public ImpliedRepoConfig getImpliedRepoConfig()
-            throws ConfigurationException
-        {
-            return getPrefabInstance();
-        }
-
-        @Override
-        public AproxConfigClassInfo getInfo()
-        {
-            return getPrefabInstance();
-        }
-    }
+//    @javax.enterprise.context.ApplicationScoped
+//    public static class FeatureConfig
+//        extends AbstractAproxFeatureConfig<ImpliedRepoConfig, ImpliedRepoConfig>
+//    {
+//        public FeatureConfig()
+//        {
+//            super( new ImpliedRepoConfig() );
+//        }
+//
+//        @Produces
+//        @Default
+//        @ApplicationScoped
+//        public ImpliedRepoConfig getImpliedRepoConfig()
+//            throws ConfigurationException
+//        {
+//            return getPrefabInstance();
+//        }
+//
+//        @Override
+//        public AproxConfigClassInfo getInfo()
+//        {
+//            return getPrefabInstance();
+//        }
+//    }
 
     @Override
     public String getDefaultConfigFileName()
@@ -183,11 +175,11 @@ public class ImpliedRepoConfig
                      .getResourceAsStream( "default-implied-repos.conf" );
     }
 
-    @Override
-    public Class<?> getConfigurationClass()
-    {
-        return getClass();
-    }
+    //    @Override
+    //    public Class<?> getConfigurationClass()
+    //    {
+    //        return getClass();
+    //    }
 
     public boolean isBlacklisted( final String url )
         throws MalformedURLException

--- a/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/conf/ImpliedRepoConfig.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/aprox/implrepo/conf/ImpliedRepoConfig.java
@@ -17,51 +17,38 @@ package org.commonjava.aprox.implrepo.conf;
 
 import java.io.File;
 import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.commonjava.aprox.conf.AbstractAproxConfigInfo;
 import org.commonjava.aprox.conf.AbstractAproxFeatureConfig;
+import org.commonjava.aprox.conf.AbstractAproxMapConfig;
 import org.commonjava.aprox.conf.AproxConfigClassInfo;
 import org.commonjava.aprox.conf.AproxConfigInfo;
 import org.commonjava.web.config.ConfigurationException;
-import org.commonjava.web.config.annotation.ConfigName;
 import org.commonjava.web.config.annotation.SectionName;
 
-@SectionName( "implied-repos" )
+@SectionName( ImpliedRepoConfig.SECTION_NAME )
 @Alternative
 @Named
 public class ImpliedRepoConfig
+    extends AbstractAproxMapConfig
+    implements AproxConfigClassInfo
 {
 
-    @javax.enterprise.context.ApplicationScoped
-    public static class ConfigInfo
-        extends AbstractAproxConfigInfo
-    {
-        public ConfigInfo()
-        {
-            super( ImpliedRepoConfig.class );
-        }
+    public static final String SECTION_NAME = "implied-repos";
 
-        @Override
-        public String getDefaultConfigFileName()
-        {
-            return new File( AproxConfigInfo.CONF_INCLUDES_DIR, "implied-repos.conf" ).getPath();
-        }
+    public static final String ENABLED_KEY = "enabled";
 
-        @Override
-        public InputStream getDefaultConfig()
-        {
-            return Thread.currentThread()
-                         .getContextClassLoader()
-                         .getResourceAsStream( "default-implied-repos.conf" );
-        }
-    }
+    public static final String INCLUDE_SNAPSHOTS_KEY = "include.snapshots";
+
+    public static final String DISABLED_HOST_KEY = "disable";
 
     public static final boolean DEFAULT_ENABLED = false;
 
@@ -70,6 +57,8 @@ public class ImpliedRepoConfig
     private Boolean enabled;
 
     private Boolean includeSnapshotRepos;
+
+    private List<String> blacklist = new ArrayList<>();
 
     public ImpliedRepoConfig()
     {
@@ -80,7 +69,6 @@ public class ImpliedRepoConfig
         return enabled == null ? DEFAULT_ENABLED : enabled;
     }
 
-    @ConfigName( "enabled" )
     public void setEnabled( final Boolean enabled )
     {
         this.enabled = enabled;
@@ -91,38 +79,113 @@ public class ImpliedRepoConfig
         return includeSnapshotRepos == null ? DEFAULT_INCLUDE_SNAPSHOT_REPOS : includeSnapshotRepos;
     }
 
-    @ConfigName( "include.snapshots" )
     public void setIncludeSnapshotRepos( final Boolean includeSnapshotRepos )
     {
         this.includeSnapshotRepos = includeSnapshotRepos;
+    }
+    
+    public void addBlacklist( final String host )
+    {
+        this.blacklist.add( host );
+    }
+
+    public boolean isBlacklisted( final URL url )
+    {
+        final String proto = url.getProtocol();
+        final String host = url.getHost();
+        int port = url.getPort();
+        if ( port < 0 )
+        {
+            port = "https".equals( proto ) ? 443 : 80;
+        }
+
+        return blacklist.contains( host ) || blacklist.contains( host + ":" + port )
+            || blacklist.contains( proto + "://" + host ) || blacklist.contains( proto + "://" + host + ":" + port );
+    }
+
+    public List<String> getBlacklist()
+    {
+        return blacklist;
+    }
+
+    public void setBlacklist( final List<String> blacklist )
+    {
+        this.blacklist = blacklist;
+    }
+
+    @Override
+    public void parameter( final String name, final String value )
+        throws ConfigurationException
+    {
+        switch ( name )
+        {
+            case ENABLED_KEY:
+            {
+                this.enabled = Boolean.parseBoolean( value );
+                break;
+            }
+            case INCLUDE_SNAPSHOTS_KEY:
+            {
+                this.includeSnapshotRepos = Boolean.parseBoolean( value );
+                break;
+            }
+            case DISABLED_HOST_KEY:
+            {
+                this.blacklist.add( value );
+                break;
+            }
+            default:
+            {
+                throw new ConfigurationException(
+                                                  "Invalid value: '{}' for parameter: '{}'. Only numeric values are accepted for section: '{}'.",
+                                                  value, name, SECTION_NAME );
+            }
+        }
     }
 
     @javax.enterprise.context.ApplicationScoped
     public static class FeatureConfig
         extends AbstractAproxFeatureConfig<ImpliedRepoConfig, ImpliedRepoConfig>
     {
-        @Inject
-        private ConfigInfo info;
-
         public FeatureConfig()
         {
-            super( ImpliedRepoConfig.class );
+            super( new ImpliedRepoConfig() );
         }
 
         @Produces
         @Default
         @ApplicationScoped
-        public ImpliedRepoConfig getFlatFileConfig()
+        public ImpliedRepoConfig getImpliedRepoConfig()
             throws ConfigurationException
         {
-            return getConfig();
+            return getPrefabInstance();
         }
 
         @Override
         public AproxConfigClassInfo getInfo()
         {
-            return info;
+            return getPrefabInstance();
         }
+    }
+
+    @Override
+    public String getDefaultConfigFileName()
+    {
+        return new File( AproxConfigInfo.CONF_INCLUDES_DIR, "implied-repos.conf" ).getPath();
+    }
+
+    @Override
+    public InputStream getDefaultConfig()
+    {
+        return Thread.currentThread()
+                     .getContextClassLoader()
+                     .getResourceAsStream( "default-implied-repos.conf" );
+    }
+
+    @Override
+    public Class<?> getConfigurationClass()
+    {
+        return getClass();
     }
 
 }

--- a/addons/implied-repos/common/src/main/resources/default-implied-repos.conf
+++ b/addons/implied-repos/common/src/main/resources/default-implied-repos.conf
@@ -19,3 +19,10 @@
 # excluded from being implied.
 #
 #include.snapshots=false
+
+# You can blacklist repositories from being implied using 'disabled' entries. These should contain
+# either the hostname or host:port.
+#
+# Disable Codehaus, since it's defunct.
+disable=snapshots.repository.codehaus.org
+disable=repository.codehaus.org

--- a/addons/indexer/src/main/java/org/commonjava/aprox/indexer/conf/IndexerConfig.java
+++ b/addons/indexer/src/main/java/org/commonjava/aprox/indexer/conf/IndexerConfig.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.indexer.conf;
 
 import java.io.File;

--- a/addons/setback/common/src/main/data/templates/application_xml/setback-settings.xml.groovy
+++ b/addons/setback/common/src/main/data/templates/application_xml/setback-settings.xml.groovy
@@ -1,18 +1,3 @@
-/**
- * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 <?xml version="1.0" encoding="UTF-8">
 <settings>
 <% def overridesCentral = false %>

--- a/api/src/main/java/org/commonjava/aprox/conf/AbstractAproxFeatureConfig.java
+++ b/api/src/main/java/org/commonjava/aprox/conf/AbstractAproxFeatureConfig.java
@@ -35,14 +35,29 @@ public abstract class AbstractAproxFeatureConfig<T, U extends T>
 
     private final Class<U> implCls;
 
+    private final T impl;
+
     AbstractAproxFeatureConfig()
     {
         implCls = null;
+        impl = null;
     }
 
     public AbstractAproxFeatureConfig( final Class<U> implCls )
     {
         this.implCls = implCls;
+        this.impl = null;
+    }
+
+    public AbstractAproxFeatureConfig( final T impl )
+    {
+        this.implCls = null;
+        this.impl = impl;
+    }
+
+    public T getPrefabInstance()
+    {
+        return impl;
     }
 
     @Inject
@@ -57,7 +72,7 @@ public abstract class AbstractAproxFeatureConfig<T, U extends T>
     protected T getConfig()
         throws ConfigurationException
     {
-        return factory.getConfiguration( implCls );
+        return impl == null ? factory.getConfiguration( implCls ) : impl;
     }
 
 }

--- a/api/src/main/java/org/commonjava/aprox/util/MimeTyper.java
+++ b/api/src/main/java/org/commonjava/aprox/util/MimeTyper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.util;
 
 import java.io.IOException;

--- a/core/src/main/java/org/commonjava/aprox/core/content/HttpMetadataCleanupGenerator.java
+++ b/core/src/main/java/org/commonjava/aprox/core/content/HttpMetadataCleanupGenerator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.core.content;
 
 import java.io.IOException;

--- a/models/core-java/src/main/java/org/commonjava/aprox/model/core/io/StoreKeyDeserializer.java
+++ b/models/core-java/src/main/java/org/commonjava/aprox/model/core/io/StoreKeyDeserializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.model.core.io;
 
 import java.io.IOException;

--- a/models/core-java/src/main/java/org/commonjava/aprox/model/core/io/StoreKeySerializer.java
+++ b/models/core-java/src/main/java/org/commonjava/aprox/model/core/io/StoreKeySerializer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.model.core.io;
 
 import java.io.IOException;

--- a/uis/layover/pom.xml
+++ b/uis/layover/pom.xml
@@ -39,5 +39,32 @@
         <directory>src/main/js/app</directory>
       </resource>
     </resources>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>2.10</version>
+          <configuration>
+            <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
+            <properties>
+              <owner>${projectOwner}</owner>
+              <email>${projectEmail}</email>
+            </properties>
+            <excludes>
+              <exclude>**/README</exclude>
+              <exclude>**/LICENSE*</exclude>
+              <exclude>src/test/resources/**</exclude>
+              <exclude>src/main/resources/**</exclude>
+              <exclude>src/main/js/app/docs/**</exclude>
+              <exclude>**/*.groovy</exclude>
+            </excludes>
+            <mapping>
+              <service>SCRIPT_STYLE</service>
+            </mapping>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 </project>


### PR DESCRIPTION
* settings templates had javadoc-style license header, which broke the generated output
* implied-repos now has the ability to blacklist detected repos like codehaus.org.