### PR TITLE
[Fixes #200] Fixing truncation of responses to httprox clients. Other minor changes.

### DIFF
--- a/addons/autoprox/client-java/pom.xml
+++ b/addons/autoprox/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-autoprox</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-autoprox-client-java</artifactId>
   <name>AProx :: Add-Ons :: Auto-Proxy :: Java Client</name>

--- a/addons/autoprox/common/pom.xml
+++ b/addons/autoprox/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-autoprox</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-autoprox-common</artifactId>
   <name>AProx :: Add-Ons :: Auto-Proxy :: Common</name>

--- a/addons/autoprox/ftests/pom.xml
+++ b/addons/autoprox/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-autoprox</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-ftests-autoprox</artifactId>

--- a/addons/autoprox/jaxrs/pom.xml
+++ b/addons/autoprox/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-autoprox</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-autoprox-jaxrs</artifactId>

--- a/addons/autoprox/model-java/pom.xml
+++ b/addons/autoprox/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-autoprox</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-autoprox-model-java</artifactId>
   <name>AProx :: Add-Ons :: Auto-Proxy :: Java Domain Model</name>

--- a/addons/autoprox/pom.xml
+++ b/addons/autoprox/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-addons</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-autoprox</artifactId>
   <name>AProx :: Add-Ons :: Auto-Proxy :: Parent</name>

--- a/addons/depgraph/common/pom.xml
+++ b/addons/depgraph/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-depgraph</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-depgraph-common</artifactId>

--- a/addons/depgraph/ftests/pom.xml
+++ b/addons/depgraph/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-depgraph</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-ftests-depgraph</artifactId>

--- a/addons/depgraph/jaxrs/pom.xml
+++ b/addons/depgraph/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-depgraph</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-depgraph-jaxrs</artifactId>

--- a/addons/depgraph/pom.xml
+++ b/addons/depgraph/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-addons</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-depgraph</artifactId>

--- a/addons/dot-maven/common/pom.xml
+++ b/addons/dot-maven/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-dot-maven</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-dot-maven-common</artifactId>
   <name>AProx :: Add-Ons :: Dot-Maven (.m2 WebDAV) :: Common Core</name>

--- a/addons/dot-maven/ftests/pom.xml
+++ b/addons/dot-maven/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-dot-maven</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-ftests-dot-maven</artifactId>

--- a/addons/dot-maven/jaxrs/pom.xml
+++ b/addons/dot-maven/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-dot-maven</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-dot-maven-jaxrs</artifactId>

--- a/addons/dot-maven/pom.xml
+++ b/addons/dot-maven/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-addons</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-dot-maven</artifactId>

--- a/addons/folo/client-java/pom.xml
+++ b/addons/folo/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-folo</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-folo-client-java</artifactId>
   <name>AProx :: Add-Ons :: Folo Usage Tracker :: Java Client</name>

--- a/addons/folo/common/pom.xml
+++ b/addons/folo/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-folo</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-folo-common</artifactId>
   <name>AProx :: Add-Ons :: Folo Usage Tracker :: Common</name>

--- a/addons/folo/ftests/pom.xml
+++ b/addons/folo/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-folo</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-ftests-folo</artifactId>

--- a/addons/folo/jaxrs/pom.xml
+++ b/addons/folo/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-folo</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-folo-jaxrs</artifactId>

--- a/addons/folo/model-java/pom.xml
+++ b/addons/folo/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-folo</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-folo-model-java</artifactId>
   <name>AProx :: Add-Ons :: Folo Usage Tracker :: Java Domain Model</name>

--- a/addons/folo/pom.xml
+++ b/addons/folo/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-addons</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-folo</artifactId>
   <name>AProx :: Add-Ons :: Folo Usage Tracker :: Parent</name>

--- a/addons/httprox/common/pom.xml
+++ b/addons/httprox/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-httprox</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-httprox-common</artifactId>
   <name>AProx :: Add-Ons :: HTTProx (HTTP Proxy) :: Common Core</name>

--- a/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/handler/ProxyAcceptHandler.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/handler/ProxyAcceptHandler.java
@@ -1,0 +1,90 @@
+package org.commonjava.aprox.httprox.handler;
+
+import org.commonjava.aprox.boot.BootOptions;
+import org.commonjava.aprox.core.ctl.ContentController;
+import org.commonjava.aprox.data.StoreDataManager;
+import org.commonjava.aprox.httprox.conf.HttproxConfig;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xnio.ChannelListener;
+import org.xnio.Pooled;
+import org.xnio.StreamConnection;
+import org.xnio.channels.AcceptingChannel;
+import org.xnio.conduits.ConduitStreamSinkChannel;
+import org.xnio.conduits.ConduitStreamSourceChannel;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Created by jdcasey on 8/13/15.
+ */
+public class ProxyAcceptHandler implements ChannelListener<AcceptingChannel<StreamConnection>>
+{
+    @Inject
+    private HttproxConfig config;
+
+    @Inject
+    private BootOptions bootOptions;
+
+    @Inject
+    private StoreDataManager storeManager;
+
+    @Inject
+    private ContentController contentController;
+
+    @Inject
+    private CacheProvider cacheProvider;
+
+    public ProxyAcceptHandler(){}
+
+    public ProxyAcceptHandler( HttproxConfig config, BootOptions bootOptions, StoreDataManager storeManager,
+                               ContentController contentController, CacheProvider cacheProvider )
+    {
+        this.config = config;
+        this.bootOptions = bootOptions;
+        this.storeManager = storeManager;
+        this.contentController = contentController;
+        this.cacheProvider = cacheProvider;
+    }
+
+    @Override
+    public void handleEvent( AcceptingChannel<StreamConnection> channel )
+    {
+        final Logger logger = LoggerFactory.getLogger( getClass() );
+
+        StreamConnection accepted;
+        try
+        {
+            accepted = channel.accept();
+        }
+        catch ( IOException e )
+        {
+            logger.error("Failed to accept httprox connection: " + e.getMessage(), e );
+            return;
+        }
+
+        logger.debug( "accepted {}", accepted.getPeerAddress() );
+
+        final ConduitStreamSourceChannel source = accepted.getSourceChannel();
+        final ConduitStreamSinkChannel sink = accepted.getSinkChannel();
+
+        final ProxyResponseWriter writer =
+                        new ProxyResponseWriter( config, storeManager, contentController, cacheProvider );
+
+        logger.debug( "Setting writer: {}", writer );
+        sink.getWriteSetter()
+            .set( writer );
+
+        final ProxyRequestReader reader = new ProxyRequestReader( writer, sink );
+
+        logger.debug( "Setting reader: {}", reader );
+        source.getReadSetter()
+              .set( reader );
+
+        source.resumeReads();
+
+    }
+}

--- a/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/handler/ProxyAcceptHandler.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/aprox/httprox/handler/ProxyAcceptHandler.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.aprox.httprox.handler;
 
 import org.commonjava.aprox.boot.BootOptions;

--- a/addons/httprox/common/src/test/java/org/commonjava/aprox/httprox/HttpProxyTest.java
+++ b/addons/httprox/common/src/test/java/org/commonjava/aprox/httprox/HttpProxyTest.java
@@ -49,6 +49,7 @@ import org.commonjava.aprox.core.content.DefaultContentManager;
 import org.commonjava.aprox.core.content.DefaultDownloadManager;
 import org.commonjava.aprox.core.ctl.ContentController;
 import org.commonjava.aprox.httprox.conf.HttproxConfig;
+import org.commonjava.aprox.httprox.handler.ProxyAcceptHandler;
 import org.commonjava.aprox.mem.data.MemoryStoreDataManager;
 import org.commonjava.aprox.model.core.RemoteRepository;
 import org.commonjava.aprox.model.core.StoreKey;
@@ -68,10 +69,7 @@ import org.commonjava.maven.galley.transport.htcli.HttpClientTransport;
 import org.commonjava.maven.galley.transport.htcli.HttpImpl;
 import org.commonjava.maven.galley.transport.htcli.util.HttpUtil;
 import org.commonjava.test.http.TestHttpServer;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -139,10 +137,13 @@ public class HttpProxyTest
         final ContentController contentController =
             new ContentController( storeManager, contentManager, templates, mapper, new MimeTyper() );
 
-        proxy = new HttpProxy( config, bootOpts, storeManager, contentController, core.getCache() );
+        proxy = new HttpProxy( config, bootOpts,
+                               new ProxyAcceptHandler( config, bootOpts, storeManager, contentController,
+                                                       core.getCache() ) );
         proxy.start();
     }
 
+    @After
     public void teardown()
     {
         if ( proxy != null )

--- a/addons/httprox/ftests/pom.xml
+++ b/addons/httprox/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-httprox</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-ftests-httprox</artifactId>

--- a/addons/httprox/ftests/src/main/java/org/commonjava/aprox/httprox/RetrievedContentMatchesContentLength_SlowClient_Test.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/aprox/httprox/RetrievedContentMatchesContentLength_SlowClient_Test.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.aprox.httprox;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.commonjava.aprox.client.core.AproxClientModule;
+import org.commonjava.aprox.client.core.helper.HttpResources;
+import org.commonjava.aprox.folo.client.AproxFoloAdminClientModule;
+import org.commonjava.aprox.folo.model.AffectedStoreRecord;
+import org.commonjava.aprox.folo.model.TrackedContentRecord;
+import org.commonjava.aprox.model.core.StoreKey;
+import org.commonjava.aprox.model.core.StoreType;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.*;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class RetrievedContentMatchesContentLength_SlowClient_Test
+                extends AbstractHttproxFunctionalTest
+{
+
+    // NOTE: anything less, and it seems like this test doesn't check for stream truncation.
+    private static final int CONTENT_LENGTH = 1024 * 384;
+
+    private static int SELECTION_OFFSET = 32; // let's get to printable ASCII characters
+
+    private static int SELECTION_RANGE_SIZE = 126 - SELECTION_OFFSET;
+                    // from the ASCII table...let's just keep it simple
+
+    private static final String USER = "user";
+
+    private static final String PASS = "password";
+
+    private Random rand = new Random();
+
+    @Test
+    public void run()
+                    throws Exception
+    {
+        final String testRepo = "test";
+        String path = "path/to/binary.bin";
+        StringBuilder content = new StringBuilder();
+        for ( int i = 0; i < CONTENT_LENGTH; i++ )
+        {
+            content.append( (char) rand.nextInt( SELECTION_RANGE_SIZE ) + SELECTION_OFFSET );
+        }
+
+        final String url = server.formatUrl( testRepo, path );
+        server.expect( url, 200, content.toString() );
+
+        final HttpGet get = new HttpGet( url );
+        final CloseableHttpClient client = proxiedHttp();
+        CloseableHttpResponse response = null;
+
+        InputStream stream = null;
+        try
+        {
+            response = client.execute( get, proxyContext( USER, PASS ) );
+            assertThat( response.getStatusLine().getStatusCode(), equalTo( 200 ) );
+
+            stream = response.getEntity().getContent();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+            byte[] buf = new byte[1024];
+            int read = -1;
+            while ( ( read = stream.read( buf ) ) > -1 )
+            {
+                baos.write( buf, 0, read );
+            }
+
+            final String resultingPom = new String(baos.toByteArray());
+
+            assertThat( resultingPom, notNullValue() );
+            assertThat( resultingPom, equalTo( content.toString() ) );
+        }
+        finally
+        {
+            IOUtils.closeQuietly( stream );
+            HttpResources.cleanupResources( get, response, client );
+        }
+    }
+
+    @Override
+    protected String getAdditionalHttproxConfig()
+    {
+        return "tracking.type=always";
+    }
+
+    @Override
+    protected int getTestTimeoutMultiplier()
+    {
+        return 2;
+    }
+}

--- a/addons/httprox/pom.xml
+++ b/addons/httprox/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-addons</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-httprox</artifactId>

--- a/addons/implied-repos/client-java/pom.xml
+++ b/addons/implied-repos/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-implied-repos</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-implied-repos-client-java</artifactId>
   <name>AProx :: Add-Ons :: Implied Repositories :: Java Client</name>

--- a/addons/implied-repos/common/pom.xml
+++ b/addons/implied-repos/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-implied-repos</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-implied-repos-common</artifactId>
   <name>AProx :: Add-Ons :: Implied Repositories :: Common</name>

--- a/addons/implied-repos/ftests/pom.xml
+++ b/addons/implied-repos/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-implied-repos</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-ftests-implied-repos</artifactId>

--- a/addons/implied-repos/model-java/pom.xml
+++ b/addons/implied-repos/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-implied-repos</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-implied-repos-model-java</artifactId>
   <name>AProx :: Add-Ons :: Implied Repositories :: Java Domain Model</name>

--- a/addons/implied-repos/pom.xml
+++ b/addons/implied-repos/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-addons</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-implied-repos</artifactId>
   <name>AProx :: Add-Ons :: Implied Repositories :: Parent</name>

--- a/addons/indexer/pom.xml
+++ b/addons/indexer/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-addons</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-indexer</artifactId>

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-addons</artifactId>

--- a/addons/promote/client-java/pom.xml
+++ b/addons/promote/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-promote</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-promote-client-java</artifactId>
   <name>AProx :: Add-Ons :: Artifact Promotion :: Java Client</name>

--- a/addons/promote/common/pom.xml
+++ b/addons/promote/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-promote</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-promote-common</artifactId>
   <name>AProx :: Add-Ons :: Artifact Promotion :: Common</name>

--- a/addons/promote/ftests/pom.xml
+++ b/addons/promote/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-promote</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-ftests-promote</artifactId>

--- a/addons/promote/jaxrs/pom.xml
+++ b/addons/promote/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-promote</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-promote-jaxrs</artifactId>

--- a/addons/promote/model-java/pom.xml
+++ b/addons/promote/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-promote</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-promote-model-java</artifactId>
   <name>AProx :: Add-Ons :: Artifact Promotion :: Java Domain Model</name>

--- a/addons/promote/pom.xml
+++ b/addons/promote/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-addons</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-promote</artifactId>
   <name>AProx :: Add-Ons :: Artifact Promotion :: Parent</name>

--- a/addons/revisions/common/pom.xml
+++ b/addons/revisions/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-revisions</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-revisions-common</artifactId>
   <name>AProx :: Add-Ons :: Revisions :: Common</name>

--- a/addons/revisions/jaxrs/pom.xml
+++ b/addons/revisions/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-revisions</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-revisions-jaxrs</artifactId>

--- a/addons/revisions/pom.xml
+++ b/addons/revisions/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-addons</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-revisions</artifactId>
   <name>AProx :: Add-Ons :: Revisions :: Parent</name>

--- a/addons/setback/common/pom.xml
+++ b/addons/setback/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-setback</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-setback-common</artifactId>
   <name>AProx :: Add-Ons :: Set-Back :: Common</name>

--- a/addons/setback/jaxrs/pom.xml
+++ b/addons/setback/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-setback</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-setback-jaxrs</artifactId>

--- a/addons/setback/pom.xml
+++ b/addons/setback/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-addons</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-setback</artifactId>
   <name>AProx :: Add-Ons :: Set-Back :: Parent</name>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-api</artifactId>

--- a/bindings/jaxrs/pom.xml
+++ b/bindings/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-bindings</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-bindings-jaxrs</artifactId>

--- a/bindings/pom.xml
+++ b/bindings/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-bindings</artifactId>

--- a/boot/api/pom.xml
+++ b/boot/api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox.boot</groupId>
     <artifactId>aprox-booters</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.aprox.boot</groupId>

--- a/boot/jaxrs/pom.xml
+++ b/boot/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox.boot</groupId>
     <artifactId>aprox-booters</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.aprox.boot</groupId>

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.aprox.boot</groupId>

--- a/clients/core-java/pom.xml
+++ b/clients/core-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-clients-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-client-core-java</artifactId>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-clients-parent</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-core</artifactId>

--- a/db/flat/pom.xml
+++ b/db/flat/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-db</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-db-flat</artifactId>

--- a/db/memory/pom.xml
+++ b/db/memory/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-db</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-db-memory</artifactId>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-db</artifactId>

--- a/deployments/launchers/base/pom.xml
+++ b/deployments/launchers/base/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox.launch</groupId>
     <artifactId>aprox-launchers</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-launcher-base</artifactId>

--- a/deployments/launchers/easyprox/pom.xml
+++ b/deployments/launchers/easyprox/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox.launch</groupId>
     <artifactId>aprox-launchers</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-launcher-easyprox</artifactId>

--- a/deployments/launchers/pom.xml
+++ b/deployments/launchers/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-deployments</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.aprox.launch</groupId>

--- a/deployments/launchers/rest-min/pom.xml
+++ b/deployments/launchers/rest-min/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox.launch</groupId>
     <artifactId>aprox-launchers</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-launcher-min</artifactId>

--- a/deployments/launchers/savant/pom.xml
+++ b/deployments/launchers/savant/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox.launch</groupId>
     <artifactId>aprox-launchers</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-launcher-savant</artifactId>

--- a/deployments/pom.xml
+++ b/deployments/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.aprox</groupId>

--- a/embedder-tests/easyprox/pom.xml
+++ b/embedder-tests/easyprox/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox.embed.test</groupId>
     <artifactId>aprox-embedder-tests</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-embedder-test-easyprox</artifactId>

--- a/embedder-tests/pom.xml
+++ b/embedder-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.aprox.embed.test</groupId>

--- a/embedder-tests/rest-min/pom.xml
+++ b/embedder-tests/rest-min/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox.embed.test</groupId>
     <artifactId>aprox-embedder-tests</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-embedder-test-min</artifactId>

--- a/embedder-tests/savant/pom.xml
+++ b/embedder-tests/savant/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox.embed.test</groupId>
     <artifactId>aprox-embedder-tests</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-embedder-test-savant</artifactId>

--- a/embedders/easyprox/pom.xml
+++ b/embedders/easyprox/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox.embed</groupId>
     <artifactId>aprox-embedders</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-embedder-easyprox</artifactId>

--- a/embedders/pom.xml
+++ b/embedders/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.aprox.embed</groupId>

--- a/embedders/rest-min/pom.xml
+++ b/embedders/rest-min/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox.embed</groupId>
     <artifactId>aprox-embedders</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-embedder-min</artifactId>

--- a/embedders/savant/pom.xml
+++ b/embedders/savant/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox.embed</groupId>
     <artifactId>aprox-embedders</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-embedder-savant</artifactId>

--- a/filers/default/pom.xml
+++ b/filers/default/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-file-managers</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-filer-default</artifactId>

--- a/filers/pom.xml
+++ b/filers/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-file-managers</artifactId>

--- a/ftests/common/pom.xml
+++ b/ftests/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-ftests-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-ftests-common</artifactId>

--- a/ftests/core/pom.xml
+++ b/ftests/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-ftests-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-ftests-core</artifactId>

--- a/ftests/pom.xml
+++ b/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-ftests-parent</artifactId>

--- a/models/core-java/pom.xml
+++ b/models/core-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-models-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-model-core-java</artifactId>

--- a/models/pom.xml
+++ b/models/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-models-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   
   <groupId>org.commonjava.aprox</groupId>
   <artifactId>aprox-parent</artifactId>
-  <version>0.23.1</version>
+  <version>0.23.2-SNAPSHOT</version>
   
   <packaging>pom</packaging>
   
@@ -98,7 +98,7 @@
       <dependency>
         <groupId>org.commonjava.aprox.ui</groupId>
         <artifactId>aprox-ui-layover</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <!-- <type>war</type> -->
         <scope>runtime</scope>
       </dependency>
@@ -106,22 +106,22 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-model-core-java</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-api</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-core</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-core</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -129,17 +129,17 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-db-flat</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-bindings-jaxrs</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox.launch</groupId>
         <artifactId>aprox-launcher-base</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <classifier>binset</classifier>
         <type>tar.gz</type>
         <scope>provided</scope>
@@ -147,7 +147,7 @@
       <dependency>
         <groupId>org.commonjava.aprox.launch</groupId>
         <artifactId>aprox-launcher-base</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
         <scope>provided</scope>
@@ -155,7 +155,7 @@
       <dependency>
         <groupId>org.commonjava.aprox.launch</groupId>
         <artifactId>aprox-launcher-base</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <classifier>dataset</classifier>
         <type>tar.gz</type>
         <scope>provided</scope>
@@ -163,12 +163,12 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-depgraph-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-depgraph-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -176,28 +176,28 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-depgraph-jaxrs</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-ftests-depgraph</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-autoprox-jaxrs</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-autoprox-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-autoprox-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>dataset</classifier>
         <scope>provided</scope>
@@ -205,7 +205,7 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-autoprox-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>docset</classifier>
         <scope>provided</scope>
@@ -213,7 +213,7 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-autoprox-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -221,7 +221,7 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-autoprox-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>uiset</classifier>
         <scope>provided</scope>
@@ -229,32 +229,32 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-autoprox-model-java</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-autoprox-client-java</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-ftests-autoprox</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-setback-jaxrs</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-setback-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-setback-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>dataset</classifier>
         <scope>provided</scope>
@@ -262,17 +262,17 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-revisions-jaxrs</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-revisions-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-revisions-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -280,7 +280,7 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-revisions-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>uiset</classifier>
         <scope>provided</scope>
@@ -288,12 +288,12 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-dot-maven-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-dot-maven-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>dataset</classifier>
         <scope>provided</scope>
@@ -301,22 +301,22 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-dot-maven-jaxrs</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-ftests-dot-maven</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-httprox-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-httprox-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -324,130 +324,130 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-ftests-httprox</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-indexer</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-indexer</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-db-memory</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-test-db</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-test-fixtures-core</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-test-providers-core</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-test-utils</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-filer-default</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-subsys-jaxrs</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-subsys-flatfile</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-subsys-http</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-subsys-maven</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-subsys-git</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-subsys-groovy</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-client-core-java</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-ftests-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-ftests-core</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-folo-jaxrs</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-ftests-folo</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-folo-client-java</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-folo-model-java</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-folo-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-folo-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>dataset</classifier>
         <scope>provided</scope>
@@ -455,7 +455,7 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-folo-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -463,38 +463,38 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-promote-jaxrs</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-ftests-promote</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-promote-client-java</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-promote-model-java</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-promote-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-implied-repos-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-implied-repos-common</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -502,52 +502,52 @@
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-implied-repos-model-java</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-implied-repos-client-java</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-ftests-implied-repos</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox.embed</groupId>
         <artifactId>aprox-embedder-min</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox.embed</groupId>
         <artifactId>aprox-embedder-easyprox</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox.embed</groupId>
         <artifactId>aprox-embedder-savant</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox.boot</groupId>
         <artifactId>aprox-booter-api</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox.boot</groupId>
         <artifactId>aprox-booter-jaxrs</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-subsys-keycloak</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.aprox</groupId>
         <artifactId>aprox-subsys-keycloak</artifactId>
-        <version>0.23.1</version>
+        <version>0.23.2-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <connection>scm:git:https://github.com/Commonjava/aprox.git</connection>
     <developerConnection>scm:git:git@github.com:Commonjava/aprox.git</developerConnection>
     <url>http://github.com/Commonjava/aprox</url>
-    <tag>aprox-parent-0.23.1</tag>
+    <tag>0.23.x</tag>
   </scm>
   
   <properties>

--- a/subsys/flatfile/pom.xml
+++ b/subsys/flatfile/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-subsystems</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-subsys-flatfile</artifactId>

--- a/subsys/git/pom.xml
+++ b/subsys/git/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-subsystems</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-subsys-git</artifactId>

--- a/subsys/groovy/pom.xml
+++ b/subsys/groovy/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-subsystems</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-subsys-groovy</artifactId>

--- a/subsys/http/pom.xml
+++ b/subsys/http/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-subsystems</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-subsys-http</artifactId>

--- a/subsys/jaxrs/pom.xml
+++ b/subsys/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-subsystems</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-subsys-jaxrs</artifactId>

--- a/subsys/keycloak/pom.xml
+++ b/subsys/keycloak/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-subsystems</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   <artifactId>aprox-subsys-keycloak</artifactId>
   <name>AProx :: Keycloak Subsystem</name>

--- a/subsys/maven/pom.xml
+++ b/subsys/maven/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-subsystems</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-subsys-maven</artifactId>

--- a/subsys/pom.xml
+++ b/subsys/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-subsystems</artifactId>

--- a/test/db/pom.xml
+++ b/test/db/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-test</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-test-db</artifactId>

--- a/test/fixtures-core/pom.xml
+++ b/test/fixtures-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-test</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-test-fixtures-core</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-test</artifactId>

--- a/test/providers-core/pom.xml
+++ b/test/providers-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-test</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-test-providers-core</artifactId>

--- a/test/utils/pom.xml
+++ b/test/utils/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-test</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-test-utils</artifactId>

--- a/tools/assemblies/pom.xml
+++ b/tools/assemblies/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox.tools</groupId>
     <artifactId>aprox-tools</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-assemblies</artifactId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.aprox.tools</groupId>

--- a/uis/layover/pom.xml
+++ b/uis/layover/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox.ui</groupId>
     <artifactId>aprox-uis</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-ui-layover</artifactId>

--- a/uis/pom.xml
+++ b/uis/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-parent</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.aprox.ui</groupId>


### PR DESCRIPTION
* Clean up functional test to express #200
* Add accept handler to separate httprox management code from operational code
* Use FileChannel and Channels.blockingTransfer (XNIO) to send response files instead of handling manually
* reset version to 0.23.2-SNAPSHOT
* license header for new class