### PR TITLE
Fix NPE when nextFire is null

### DIFF
--- a/core/src/main/java/org/commonjava/aprox/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/aprox/core/expire/ScheduleManager.java
@@ -447,7 +447,7 @@ public class ScheduleManager
                 }
 
                 final Date nextFire = trigger.getFireTimeAfter( new Date() );
-                if ( !nextFire.after( to ) )
+                if ( nextFire == null || !nextFire.after( to ) )
                 {
                     scheduler.unscheduleJob( key );
                     canceled.add( key );


### PR DESCRIPTION
I guess this situation can occur when there is stored a firetime before
current datetime. In this case getFireTimeAfter will return null.
Therefore null should be handled the same way as if nextFire is before
or equals to "to" value.