### PR TITLE
Align with mutator config changes in GraphDescription

### DIFF
--- a/addons/depgraph/common/src/main/java/org/commonjava/aprox/depgraph/rest/RenderingController.java
+++ b/addons/depgraph/common/src/main/java/org/commonjava/aprox/depgraph/rest/RenderingController.java
@@ -192,7 +192,7 @@ public class RenderingController
         final RepositoryContentRequest dto = new RepositoryContentRequest();
         dto.setWorkspaceId( workspaceId );
 
-        final GraphDescription desc = new GraphDescription( filter, ref );
+        final GraphDescription desc = new GraphDescription( filter, null, ref );
         dto.setGraphComposition( new GraphComposition( GraphCalculationType.ADD, Collections.singletonList( desc ) ) );
 
         return tree( dto );

--- a/addons/depgraph/common/src/test/java/org/commonjava/aprox/depgraph/dto/PomRecipeTest.java
+++ b/addons/depgraph/common/src/test/java/org/commonjava/aprox/depgraph/dto/PomRecipeTest.java
@@ -44,7 +44,7 @@ public class PomRecipeTest
                                    new ProjectRelationshipSerializerModule() );
 
         final GraphDescription desc =
-            new GraphDescription( "runtime", Collections.<String, Object> emptyMap(),
+            new GraphDescription( "runtime", null, Collections.<String, Object> emptyMap(),
                                   Collections.singleton( new SimpleProjectVersionRef( "org.foo", "bar", "1.0" ) ) );
 
         final GraphComposition comp = new GraphComposition( null, Collections.singletonList( desc ) );


### PR DESCRIPTION
This just adds null value in the GraphDescription constructor to use the default mutator.

Follows https://github.com/Commonjava/cartographer/pull/87